### PR TITLE
Fix #3 by explicitly instantiating std::string template

### DIFF
--- a/src/rttr/detail/misc/standard_types.cpp
+++ b/src/rttr/detail/misc/standard_types.cpp
@@ -32,6 +32,8 @@
 #include <list>
 #include <set>
 
+template class std::basic_string<char>;
+
 RTTR_REGISTRATION
 {
     using namespace rttr;


### PR DESCRIPTION
The linker error occurs due to the attributes ` __attribute__ ((__visibility__("hidden"), __always_inline__))` specified for the `std::string` methods in question.

It can be fixed by explicitly instantiating the `std::string` template as described [here](https://stackoverflow.com/questions/29324619/taking-pointer-to-member-stdstringsize-fails-to-link-with-libc-but-works-w).