### PR TITLE
bug in array_range<>::begin() functions

### DIFF
--- a/src/rttr/detail/impl/array_range_impl.h
+++ b/src/rttr/detail/impl/array_range_impl.h
@@ -60,6 +60,10 @@ RTTR_INLINE array_range<T, Predicate>::array_range()
 template<typename T, typename Predicate>
 RTTR_INLINE typename array_range<T, Predicate>::const_iterator array_range<T, Predicate>::begin()
 {
+    if (empty())
+    {
+        return {nullptr, this};
+    }
     const_iterator itr(m_begin, this);
     if (m_pred(*itr))
         return itr;
@@ -82,6 +86,10 @@ RTTR_INLINE typename array_range<T, Predicate>::const_iterator array_range<T, Pr
 template<typename T, typename Predicate>
 RTTR_INLINE typename array_range<T, Predicate>::const_iterator array_range<T, Predicate>::begin() const
 {
+    if (empty())
+    {
+        return {nullptr, this};
+    }
     const_iterator itr(m_begin, this);
     if (m_pred(*itr))
         return itr;
@@ -104,6 +112,10 @@ RTTR_INLINE typename array_range<T, Predicate>::const_iterator array_range<T, Pr
 template<typename T, typename Predicate>
 RTTR_INLINE typename array_range<T, Predicate>::const_iterator array_range<T, Predicate>::cbegin() const
 {
+    if (empty())
+    {
+        return {nullptr, this};
+    }
     const_iterator itr(m_begin, this);
     if (m_pred(*itr))
         return itr;

--- a/src/rttr/detail/property/property_wrapper_base.h
+++ b/src/rttr/detail/property/property_wrapper_base.h
@@ -80,6 +80,9 @@ class RTTR_API property_wrapper_base
         //! Returns true when the underlying property is an array type.
         virtual bool is_array() const = 0;
 
+	 //! Returns true when the underlying property is a pointer type.
+        virtual bool is_pointer() const = 0;
+	
         //! Sets this property of the given instance \p instance to the value of the argument \p argument.
         virtual bool set_value(instance& object, argument& arg) const = 0;
 

--- a/src/rttr/detail/property/property_wrapper_func.h
+++ b/src/rttr/detail/property/property_wrapper_func.h
@@ -58,6 +58,7 @@ class property_wrapper<function_ptr, Getter, Setter, Acc_Level, return_as_copy, 
         bool is_static()    const   { return true; }
         type get_type()     const   { return type::get<return_type>(); }
         bool is_array()     const   { return detail::is_array<return_type>::value; }
+        bool is_pointer()   const   { return std::is_pointer<return_type>::value; }
 
         variant get_metadata(const variant& key) const { return metadata_handler<Metadata_Count>::get_metadata(key); }
 
@@ -107,6 +108,7 @@ class property_wrapper<function_ptr, Getter, void, Acc_Level, return_as_copy, re
         bool is_static()    const   { return true; }
         type get_type()     const   { return type::get<return_type>(); }
         bool is_array()     const   { return detail::is_array<return_type>::value; }
+        bool is_pointer()   const   { return std::is_pointer<return_type>::value; }
 
         variant get_metadata(const variant& key) const { return metadata_handler<Metadata_Count>::get_metadata(key); }
 
@@ -160,7 +162,8 @@ class property_wrapper<function_ptr, Getter, Setter, Acc_Level, return_as_ptr, s
         bool is_static()    const   { return true; }
         type get_type()     const   { return type::get<typename std::remove_reference<return_type>::type*>(); }
         bool is_array()     const   { return detail::is_array<return_type>::value; }
-
+        bool is_pointer()   const   { return std::is_pointer<return_type>::value; }
+        
         variant get_metadata(const variant& key) const { return metadata_handler<Metadata_Count>::get_metadata(key); }
 
         bool set_value(instance& object, argument& arg) const
@@ -209,6 +212,7 @@ class property_wrapper<function_ptr, Getter, void, Acc_Level, return_as_ptr, rea
         bool is_static()    const   { return true; }
         type get_type()     const   { return type::get<typename std::add_const<typename std::remove_reference<return_type>::type>::type*>(); }
         bool is_array()     const   { return detail::is_array<return_type>::value; }
+        bool is_pointer()   const   { return std::is_pointer<return_type>::value; }
 
         variant get_metadata(const variant& key) const { return metadata_handler<Metadata_Count>::get_metadata(key); }
 

--- a/src/rttr/detail/property/property_wrapper_member_func.h
+++ b/src/rttr/detail/property/property_wrapper_member_func.h
@@ -60,6 +60,7 @@ class property_wrapper<member_func_ptr, Getter, Setter, Acc_Level, return_as_cop
         bool is_static()    const   { return false; }
         type get_type()     const   { return type::get<return_type>(); }
         bool is_array()     const   { return detail::is_array<return_type>::value; }
+        bool is_pointer()   const   { return std::is_pointer<return_type>::value; }
 
         variant get_metadata(const variant& key) const { return metadata_handler<Metadata_Count>::get_metadata(key); }
 
@@ -114,6 +115,7 @@ class property_wrapper<member_func_ptr, Getter, void, Acc_Level, return_as_copy,
         bool is_static()    const   { return false; }
         type get_type()     const   { return type::get<return_type>(); }
         bool is_array()     const   { return detail::is_array<return_type>::value; }
+        bool is_pointer()   const   { return std::is_pointer<return_type>::value; }
 
         variant get_metadata(const variant& key) const { return metadata_handler<Metadata_Count>::get_metadata(key); }
 
@@ -169,6 +171,7 @@ class property_wrapper<member_func_ptr, Getter, Setter, Acc_Level, return_as_ptr
         bool is_static()    const   { return false; }
         type get_type()     const   { return type::get<typename std::remove_reference<return_type>::type*>(); }
         bool is_array()     const   { return detail::is_array<return_type>::value; }
+        bool is_pointer()   const   { return std::is_pointer<return_type>::value; }
 
         variant get_metadata(const variant& key) const { return metadata_handler<Metadata_Count>::get_metadata(key); }
 
@@ -228,6 +231,7 @@ class property_wrapper<member_func_ptr, Getter, void, Acc_Level, return_as_ptr, 
         bool is_static()    const   { return false; }
         type get_type()     const   { return type::get<policy_type>(); }
         bool is_array()     const   { return detail::is_array<return_type>::value; }
+        bool is_pointer()   const   { return std::is_pointer<return_type>::value; }
 
         variant get_metadata(const variant& key) const { return metadata_handler<Metadata_Count>::get_metadata(key); }
 

--- a/src/rttr/detail/property/property_wrapper_member_object.h
+++ b/src/rttr/detail/property/property_wrapper_member_object.h
@@ -51,6 +51,7 @@ class property_wrapper<member_object_ptr, A(C::*), void, Acc_Level, return_as_co
         bool is_static()    const   { return false; }
         type get_type()     const   { return type::get<A>(); }
         bool is_array()     const   { return detail::is_array<A>::value; }
+        bool is_pointer()   const   { return std::is_pointer<A>::value; }
 
         variant get_metadata(const variant& key) const { return metadata_handler<Metadata_Count>::get_metadata(key); }
 
@@ -99,6 +100,7 @@ class property_wrapper<member_object_ptr, A(C::*), void, Acc_Level, return_as_co
         bool is_static()    const   { return false; }
         type get_type()     const   { return type::get<A>(); }
         bool is_array()     const   { return detail::is_array<A>::value; }
+        bool is_pointer()   const   { return std::is_pointer<A>::value; }
 
         variant get_metadata(const variant& key) const { return metadata_handler<Metadata_Count>::get_metadata(key); }
 
@@ -144,6 +146,7 @@ class property_wrapper<member_object_ptr, A(C::*), void, Acc_Level, return_as_pt
         bool is_static()    const   { return false; }
         type get_type()     const   { return type::get<A*>(); }
         bool is_array()     const   { return detail::is_array<A>::value; }
+        bool is_pointer()   const   { return std::is_pointer<A>::value; }
 
         variant get_metadata(const variant& key) const { return metadata_handler<Metadata_Count>::get_metadata(key); }
 
@@ -196,6 +199,7 @@ class property_wrapper<member_object_ptr, A(C::*), void, Acc_Level, return_as_pt
         bool is_static()    const   { return false; }
         type get_type()     const   { return type::get<typename std::add_const<A>::type*>(); }
         bool is_array()     const   { return detail::is_array<A>::value; }
+        bool is_pointer()   const   { return std::is_pointer<A>::value; }
 
         variant get_metadata(const variant& key) const { return metadata_handler<Metadata_Count>::get_metadata(key); }
 

--- a/src/rttr/detail/property/property_wrapper_object.h
+++ b/src/rttr/detail/property/property_wrapper_object.h
@@ -50,7 +50,8 @@ class property_wrapper<object_ptr, C*, void, Acc_Level, return_as_copy, set_valu
         bool is_static()    const   { return true; }
         type get_type()     const   { return type::get<C>(); }
         bool is_array()     const   { return detail::is_array<C>::value; }
-
+	bool is_pointer()   const   { return std::is_pointer<C>::value; }
+	
         variant get_metadata(const variant& key) const { return metadata_handler<Metadata_Count>::get_metadata(key); }
 
         bool set_value(instance& object, argument& arg) const
@@ -95,7 +96,8 @@ class property_wrapper<object_ptr, C*, void, Acc_Level, return_as_copy, read_onl
         bool is_static()    const   { return true; }
         type get_type()     const   { return type::get<C>(); }
         bool is_array()     const   { return detail::is_array<C>::value; }
-
+	bool is_pointer()   const   { return std::is_pointer<C>::value; }
+	
         variant get_metadata(const variant& key) const { return metadata_handler<Metadata_Count>::get_metadata(key); }
 
         bool set_value(instance& object, argument& arg) const
@@ -135,6 +137,7 @@ class property_wrapper<object_ptr, C*, void, Acc_Level, return_as_ptr, set_as_pt
         bool is_static()    const   { return false; }
         type get_type()     const   { return type::get<C*>(); }
         bool is_array()     const   { return detail::is_array<C>::value; }
+        bool is_pointer()   const   { return std::is_pointer<C>::value; }
 
         variant get_metadata(const variant& key) const { return metadata_handler<Metadata_Count>::get_metadata(key); }
 
@@ -180,6 +183,7 @@ class property_wrapper<object_ptr, C*, void, Acc_Level, return_as_ptr, read_only
         bool is_static()    const   { return true; }
         type get_type()     const   { return type::get<typename std::add_const<C>::type*>(); }
         bool is_array()     const   { return detail::is_array<C>::value; }
+        bool is_pointer()   const   { return std::is_pointer<C>::value; }
 
         variant get_metadata(const variant& key) const { return metadata_handler<Metadata_Count>::get_metadata(key); }
 

--- a/src/rttr/property.cpp
+++ b/src/rttr/property.cpp
@@ -133,6 +133,16 @@ bool property::is_array() const
 
 /////////////////////////////////////////////////////////////////////////////////////////
 
+bool property::is_pointer() const
+{
+    if (is_valid())
+        return m_wrapper->is_pointer();
+    else
+        return false;
+}
+
+/////////////////////////////////////////////////////////////////////////////////////////
+
 string_view property::get_name() const
 {
     if (is_valid())

--- a/src/rttr/property.h
+++ b/src/rttr/property.h
@@ -189,6 +189,16 @@ class RTTR_API property
          */
         bool is_array() const;
 
+	
+        /*!
+         * \brief Returns true if the underlying property is a \ref pointer.
+         *
+         * \remark When the property is not valid, this function will return false.
+         *
+         * \return True if this is a \ref pointer type, otherwise false.
+         */
+        bool is_pointer() const;
+	
         /*!
          * \brief Returns the name of this property.
          *


### PR DESCRIPTION
I updated to the latest git version. When executed my crazy test program again, I got a crash in the update_class_list function. I recognized if the array_range<> is empty and it have a predicate then there is a crash in the array_range<>::begin() function.
Everything works fine, after applying my patch.
