### PR TITLE
Replaced wrong RTTR_CXX14_CONSTEXPR macros

### DIFF
--- a/src/rttr/detail/impl/enum_flags_impl.h
+++ b/src/rttr/detail/impl/enum_flags_impl.h
@@ -78,7 +78,7 @@ RTTR_CONSTEXPR RTTR_INLINE enum_flags<Enum>::enum_flags(detail::enum_flag f) RTT
 /////////////////////////////////////////////////////////////////////////////////////////
 
 template<typename Enum>
-RTTR_NO_CXX14_CONSTEXPR RTTR_INLINE enum_flags<Enum>& enum_flags<Enum>::operator&=(int mask) RTTR_NOEXCEPT
+RTTR_CXX14_CONSTEXPR RTTR_INLINE enum_flags<Enum>& enum_flags<Enum>::operator&=(int mask) RTTR_NOEXCEPT
 {
     m_value &= mask;
     return *this;
@@ -87,7 +87,7 @@ RTTR_NO_CXX14_CONSTEXPR RTTR_INLINE enum_flags<Enum>& enum_flags<Enum>::operator
 /////////////////////////////////////////////////////////////////////////////////////////
 
 template<typename Enum>
-RTTR_NO_CXX14_CONSTEXPR RTTR_INLINE enum_flags<Enum>& enum_flags<Enum>::operator&=(uint32_t mask) RTTR_NOEXCEPT
+RTTR_CXX14_CONSTEXPR RTTR_INLINE enum_flags<Enum>& enum_flags<Enum>::operator&=(uint32_t mask) RTTR_NOEXCEPT
 {
     m_value &= mask;
     return *this;
@@ -96,7 +96,7 @@ RTTR_NO_CXX14_CONSTEXPR RTTR_INLINE enum_flags<Enum>& enum_flags<Enum>::operator
 /////////////////////////////////////////////////////////////////////////////////////////
 
 template<typename Enum>
-RTTR_NO_CXX14_CONSTEXPR RTTR_INLINE enum_flags<Enum>& enum_flags<Enum>::operator&=(Enum mask) RTTR_NOEXCEPT
+RTTR_CXX14_CONSTEXPR RTTR_INLINE enum_flags<Enum>& enum_flags<Enum>::operator&=(Enum mask) RTTR_NOEXCEPT
 {
     m_value &= static_cast<enum_type>(mask);
     return *this;
@@ -105,7 +105,7 @@ RTTR_NO_CXX14_CONSTEXPR RTTR_INLINE enum_flags<Enum>& enum_flags<Enum>::operator
 /////////////////////////////////////////////////////////////////////////////////////////
 
 template<typename Enum>
-RTTR_NO_CXX14_CONSTEXPR RTTR_INLINE enum_flags<Enum>& enum_flags<Enum>::operator|=(enum_flags f) RTTR_NOEXCEPT
+RTTR_CXX14_CONSTEXPR RTTR_INLINE enum_flags<Enum>& enum_flags<Enum>::operator|=(enum_flags f) RTTR_NOEXCEPT
 {
     m_value |= f.m_value;
     return *this;
@@ -114,7 +114,7 @@ RTTR_NO_CXX14_CONSTEXPR RTTR_INLINE enum_flags<Enum>& enum_flags<Enum>::operator
 /////////////////////////////////////////////////////////////////////////////////////////
 
 template<typename Enum>
-RTTR_NO_CXX14_CONSTEXPR RTTR_INLINE enum_flags<Enum>& enum_flags<Enum>::operator|=(Enum f) RTTR_NOEXCEPT
+RTTR_CXX14_CONSTEXPR RTTR_INLINE enum_flags<Enum>& enum_flags<Enum>::operator|=(Enum f) RTTR_NOEXCEPT
 {
     m_value |= static_cast<enum_type>(f);
     return *this;
@@ -123,7 +123,7 @@ RTTR_NO_CXX14_CONSTEXPR RTTR_INLINE enum_flags<Enum>& enum_flags<Enum>::operator
 /////////////////////////////////////////////////////////////////////////////////////////
 
 template<typename Enum>
-RTTR_NO_CXX14_CONSTEXPR RTTR_INLINE enum_flags<Enum>& enum_flags<Enum>::operator^=(enum_flags f) RTTR_NOEXCEPT
+RTTR_CXX14_CONSTEXPR RTTR_INLINE enum_flags<Enum>& enum_flags<Enum>::operator^=(enum_flags f) RTTR_NOEXCEPT
 {
     m_value ^= f.m_value;
     return *this;
@@ -132,7 +132,7 @@ RTTR_NO_CXX14_CONSTEXPR RTTR_INLINE enum_flags<Enum>& enum_flags<Enum>::operator
 /////////////////////////////////////////////////////////////////////////////////////////
 
 template<typename Enum>
-RTTR_NO_CXX14_CONSTEXPR RTTR_INLINE enum_flags<Enum>& enum_flags<Enum>::operator^=(Enum f) RTTR_NOEXCEPT
+RTTR_CXX14_CONSTEXPR RTTR_INLINE enum_flags<Enum>& enum_flags<Enum>::operator^=(Enum f) RTTR_NOEXCEPT
 {
     m_value ^= static_cast<enum_type>(f);
     return *this;

--- a/src/rttr/enum_flags.h
+++ b/src/rttr/enum_flags.h
@@ -120,7 +120,7 @@ class enum_flags
          *
          * \return A reference to this object.
          */
-        RTTR_NO_CXX14_CONSTEXPR RTTR_INLINE enum_flags& operator&=(int mask) RTTR_NOEXCEPT;
+        RTTR_CXX14_CONSTEXPR RTTR_INLINE enum_flags& operator&=(int mask) RTTR_NOEXCEPT;
 
         /*!
          * \brief Performs a bitwise `AND` operation with \p mask
@@ -128,7 +128,7 @@ class enum_flags
          *
          * \return A reference to this object.
          */
-        RTTR_NO_CXX14_CONSTEXPR RTTR_INLINE enum_flags& operator&=(uint32_t mask) RTTR_NOEXCEPT;
+        RTTR_CXX14_CONSTEXPR RTTR_INLINE enum_flags& operator&=(uint32_t mask) RTTR_NOEXCEPT;
 
         /*!
          * \brief Performs a bitwise `AND` operation with \p mask
@@ -136,7 +136,7 @@ class enum_flags
          *
          * \return A reference to this object.
          */
-        RTTR_NO_CXX14_CONSTEXPR RTTR_INLINE enum_flags& operator&=(Enum mask) RTTR_NOEXCEPT;
+        RTTR_CXX14_CONSTEXPR RTTR_INLINE enum_flags& operator&=(Enum mask) RTTR_NOEXCEPT;
 
         /*!
          * \brief Performs a bitwise `OR` operation with \p f
@@ -144,7 +144,7 @@ class enum_flags
          *
          * \return A reference to this object.
          */
-        RTTR_NO_CXX14_CONSTEXPR RTTR_INLINE enum_flags& operator|=(enum_flags f) RTTR_NOEXCEPT;
+        RTTR_CXX14_CONSTEXPR RTTR_INLINE enum_flags& operator|=(enum_flags f) RTTR_NOEXCEPT;
 
         /*!
          * \brief Performs a bitwise `OR` operation with \p f
@@ -152,7 +152,7 @@ class enum_flags
          *
          * \return A reference to this object.
          */
-        RTTR_NO_CXX14_CONSTEXPR RTTR_INLINE enum_flags& operator|=(Enum f) RTTR_NOEXCEPT;
+        RTTR_CXX14_CONSTEXPR RTTR_INLINE enum_flags& operator|=(Enum f) RTTR_NOEXCEPT;
 
         /*!
          * \brief Performs a bitwise `XOR` operation with \p f
@@ -160,7 +160,7 @@ class enum_flags
          *
          * \return A reference to this object.
          */
-        RTTR_NO_CXX14_CONSTEXPR RTTR_INLINE enum_flags& operator^=(enum_flags f) RTTR_NOEXCEPT;
+        RTTR_CXX14_CONSTEXPR RTTR_INLINE enum_flags& operator^=(enum_flags f) RTTR_NOEXCEPT;
 
         /*!
          * \brief Performs a bitwise `XOR` operation with \p f
@@ -168,7 +168,7 @@ class enum_flags
          *
          * \return A reference to this object.
          */
-        RTTR_NO_CXX14_CONSTEXPR RTTR_INLINE enum_flags& operator^=(Enum f) RTTR_NOEXCEPT;
+        RTTR_CXX14_CONSTEXPR RTTR_INLINE enum_flags& operator^=(Enum f) RTTR_NOEXCEPT;
 
         /*!
          * \brief Performs a bitwise `XOR` operation with \p f


### PR DESCRIPTION
I replaced some occurrences of the RTTR_NO_CXX14_CONSTEXPR macro which I believe is used mistakenly in these places.