### PR TITLE
Fix -Wswitch warning

### DIFF
--- a/src/rttr/detail/variant/variant_data_policy.h
+++ b/src/rttr/detail/variant/variant_data_policy.h
@@ -600,6 +600,7 @@ struct RTTR_API variant_data_policy_empty
             case variant_policy_operation::DESTROY:
             case variant_policy_operation::CLONE:
             case variant_policy_operation::SWAP:
+            case variant_policy_operation::EXTRACT_WRAPPED_VALUE:
             {
                 break;
             }


### PR DESCRIPTION
variant_data_policy.h:598:17: warning: enumeration value 'EXTRACT_WRAPPED_VALUE' not handled in switch [-Wswitch]