### PR TITLE
Feature use custom name in templates

### DIFF
--- a/src/rttr/detail/misc/standard_types.cpp
+++ b/src/rttr/detail/misc/standard_types.cpp
@@ -61,10 +61,12 @@ RTTR_REGISTRATION
     RTTR_REGISTRATION_STANDARD_TYPE_VARIANTS(double)
     RTTR_REGISTRATION_STANDARD_TYPE_VARIANTS(long double)
     RTTR_REGISTRATION_STANDARD_TYPE_VARIANTS(std::string)
-    type::get<std::vector<bool>>();
-    type::get<std::vector<int>>();
-    type::get<std::vector<float>>();
-    type::get<std::vector<double>>();
+
+    registration::class_<std::vector<bool>>("std::vector<bool>");
+    registration::class_<std::vector<int>>("std::vector<int>");
+    registration::class_<std::vector<float>>("std::vector<float>");
+    registration::class_<std::vector<double>>("std::vector<double>");
+
 
     registration::class_<std::string>("std::string")
                 .constructor<>()

--- a/src/rttr/detail/type/type_data.h
+++ b/src/rttr/detail/type/type_data.h
@@ -202,10 +202,10 @@ struct raw_type_info<T, false>
 
 /////////////////////////////////////////////////////////////////////////////////
 
-template<typename T, bool = std::is_same<T, typename raw_array_type<T>::type >::value>
+template<typename T, bool = std::is_array<T>::value>
 struct array_raw_type
 {
-    static RTTR_INLINE type get_type() RTTR_NOEXCEPT { return get_invalid_type(); } // we have to return an empty type, so we can stop the recursion
+    static RTTR_INLINE type get_type() RTTR_NOEXCEPT { return type::get<raw_array_type_t<T>>(); }
 };
 
 /////////////////////////////////////////////////////////////////////////////////
@@ -213,7 +213,7 @@ struct array_raw_type
 template<typename T>
 struct array_raw_type<T, false>
 {
-    static RTTR_INLINE type get_type() RTTR_NOEXCEPT { return type::get<typename raw_array_type<T>::type>(); }
+    static RTTR_INLINE type get_type() RTTR_NOEXCEPT { return get_invalid_type(); } // we have to return an empty type, so we can stop the recursion
 };
 
 /////////////////////////////////////////////////////////////////////////////////////////

--- a/src/rttr/detail/type/type_register.cpp
+++ b/src/rttr/detail/type/type_register.cpp
@@ -489,7 +489,7 @@ std::string type_register_private::derive_template_instance_name(type_data& info
 
 /////////////////////////////////////////////////////////////////////////////////////////
 
-void type_register_private::update_custom_name(std::string new_name, type& t)
+void type_register_private::update_custom_name(std::string new_name, const type& t)
 {
     auto& type_name = t.m_type_data->name;
 

--- a/src/rttr/detail/type/type_register_p.h
+++ b/src/rttr/detail/type/type_register_p.h
@@ -169,12 +169,17 @@ private:
     template<typename T>
     static void update_class_list(const type& t, T item_ptr);
 
-    static std::string derive_name(const type_data& wrapper_type,
-                                   const type_data& array_raw_type,
-                                   string_view name);
+    static std::string derive_name(const type_data& type);
     //! Returns true, when the name was already registered
     static bool register_name(uint16_t& id, type_data& info);
     static void register_base_class_info(type_data& info);
+    /*!
+     * \brief This will update the name of the template parameters of a template instance, whith all custom names
+     * e.g.: `std::reference_wrapper<class std::basic_string<char,struct std::char_traits<char>,class std::allocator<char> > >` =>
+     *       `std::reference_wrapper<class std::string>`
+     *
+     */
+    static void update_template_instance_name(type_data& info);
 
 };
 

--- a/src/rttr/detail/type/type_register_p.h
+++ b/src/rttr/detail/type/type_register_p.h
@@ -169,17 +169,22 @@ private:
     template<typename T>
     static void update_class_list(const type& t, T item_ptr);
 
-    static std::string derive_name(const type_data& type);
+    static std::string derive_name(const type& t);
     //! Returns true, when the name was already registered
     static bool register_name(uint16_t& id, type_data& info);
     static void register_base_class_info(type_data& info);
     /*!
-     * \brief This will update the name of the template parameters of a template instance, whith all custom names
+     * \brief This will create the derived name of a template instance, with all the custom names of a template parameter.
      * e.g.: `std::reference_wrapper<class std::basic_string<char,struct std::char_traits<char>,class std::allocator<char> > >` =>
      *       `std::reference_wrapper<class std::string>`
      *
      */
-    static void update_template_instance_name(type_data& info);
+    static std::string derive_template_instance_name(type_data& info);
+
+    /*!
+     * Updates the custom name for the given type \p t with \p new_name
+     */
+    static void update_custom_name(std::string new_name, type& t);
 
 };
 

--- a/src/rttr/detail/type/type_register_p.h
+++ b/src/rttr/detail/type/type_register_p.h
@@ -184,7 +184,7 @@ private:
     /*!
      * Updates the custom name for the given type \p t with \p new_name
      */
-    static void update_custom_name(std::string new_name, type& t);
+    static void update_custom_name(std::string new_name, const type& t);
 
 };
 


### PR DESCRIPTION
will also appear when he use used as template parameter
in a template instance.
e.g:
```
std::reference_wrapper<class std::basic_string<char,struct std::char_traits<char>,class std::allocator<char> > >
std::reference_wrapper<class std::string>
```

fixes #40