### PR TITLE
Add new variant comparators

### DIFF
--- a/src/rttr/detail/comparison/compare_array_equal_impl.h
+++ b/src/rttr/detail/comparison/compare_array_equal_impl.h
@@ -46,9 +46,9 @@ namespace detail
 template<typename ElementType>
 struct compare_array_equal_impl
 {
-    bool operator()(const ElementType &lhs, const ElementType &rhs)
+    bool operator()(const ElementType &lhs, const ElementType &rhs, bool& ok)
     {
-        return compare_equal(lhs, rhs);
+        return compare_equal(lhs, rhs, ok);
     }
 };
 
@@ -57,11 +57,11 @@ struct compare_array_equal_impl
 template<typename ElementType, std::size_t Count>
 struct compare_array_equal_impl<ElementType[Count]>
 {
-    bool operator()(const ElementType (&lhs)[Count], const ElementType (&rhs)[Count])
+    bool operator()(const ElementType (&lhs)[Count], const ElementType (&rhs)[Count], bool& ok)
     {
         for(std::size_t i = 0; i < Count; ++i)
         {
-            if (!compare_array_equal_impl<ElementType>()(lhs[i], rhs[i]))
+            if (!compare_array_equal_impl<ElementType>()(lhs[i], rhs[i], ok))
                 return false;
         }
 
@@ -73,9 +73,9 @@ struct compare_array_equal_impl<ElementType[Count]>
 /////////////////////////////////////////////////////////////////////////////////////////
 
 template<typename ElementType, std::size_t Count>
-RTTR_INLINE bool compare_array_equal(const ElementType (&lhs)[Count], const ElementType (&rhs)[Count])
+RTTR_INLINE bool compare_array_equal(const ElementType (&lhs)[Count], const ElementType (&rhs)[Count], bool& ok)
 {
-    return compare_array_equal_impl<ElementType[Count]>()(lhs, rhs);
+    return compare_array_equal_impl<ElementType[Count]>()(lhs, rhs, ok);
 }
 
 /////////////////////////////////////////////////////////////////////////////////////////

--- a/src/rttr/detail/comparison/compare_equal.cpp
+++ b/src/rttr/detail/comparison/compare_equal.cpp
@@ -39,11 +39,15 @@ namespace detail
 
 /////////////////////////////////////////////////////////////////////////////////////////
 
-bool compare_types_equal(const void* lhs, const void* rhs, const type& t)
+bool compare_types_equal(const void* lhs, const void* rhs, const type& t, bool& ok)
 {
     if (auto cmp_f = type_register_private::get_equal_comparator(t))
+    {
+        ok = true;
         return cmp_f->cmp(lhs, rhs);
+    }
 
+    ok = false;
     return false;
 }
 

--- a/src/rttr/detail/comparison/compare_equal.h
+++ b/src/rttr/detail/comparison/compare_equal.h
@@ -44,7 +44,7 @@ namespace detail
 
 /////////////////////////////////////////////////////////////////////////////////////////
 
-RTTR_API bool compare_types_equal(const void* lhs, const void* rhs, const type& t);
+RTTR_API bool compare_types_equal(const void* lhs, const void* rhs, const type& t, bool& ok);
 
 /////////////////////////////////////////////////////////////////////////////////////////
 /////////////////////////////////////////////////////////////////////////////////////////
@@ -66,19 +66,19 @@ using is_equal_comparable = std::integral_constant<bool, has_equal_operator_impl
 
 template<typename T>
 RTTR_INLINE typename std::enable_if<is_equal_comparable<T>::value && !std::is_array<T>::value, bool>::type
-compare_equal(const T& lhs, const T& rhs);
+compare_equal(const T& lhs, const T& rhs, bool& ok);
 
 /////////////////////////////////////////////////////////////////////////////////////////
 
 template<typename T>
 RTTR_INLINE typename std::enable_if<!is_equal_comparable<T>::value && !std::is_array<T>::value, bool>::type
-compare_equal(const T& lhs, const T& rhs);
+compare_equal(const T& lhs, const T& rhs, bool& ok);
 
 /////////////////////////////////////////////////////////////////////////////////////////
 
 template<typename T>
 RTTR_INLINE typename std::enable_if<!is_equal_comparable<T>::value && std::is_array<T>::value, bool>::type
-compare_equal(const T& lhs, const T& rhs);
+compare_equal(const T& lhs, const T& rhs, bool& ok);
 
 /////////////////////////////////////////////////////////////////////////////////////////
 

--- a/src/rttr/detail/comparison/compare_equal_impl.h
+++ b/src/rttr/detail/comparison/compare_equal_impl.h
@@ -49,8 +49,9 @@ namespace detail
  */
 template<typename T>
 RTTR_INLINE typename std::enable_if<is_equal_comparable<T>::value && !std::is_array<T>::value, bool>::type
-compare_equal(const T& lhs, const T& rhs)
+compare_equal(const T& lhs, const T& rhs, bool& ok)
 {
+    ok = true;
     return (lhs == rhs);
 }
 
@@ -58,18 +59,18 @@ compare_equal(const T& lhs, const T& rhs)
 
 template<typename T>
 RTTR_INLINE typename std::enable_if<!is_equal_comparable<T>::value && !std::is_array<T>::value, bool>::type
-compare_equal(const T& lhs, const T& rhs)
+compare_equal(const T& lhs, const T& rhs, bool& ok)
 {
-    return compare_types_equal(&lhs, &rhs, type::get<T>());
+    return compare_types_equal(&lhs, &rhs, type::get<T>(), ok);
 }
 
 /////////////////////////////////////////////////////////////////////////////////////////
 
 template<typename T>
 RTTR_INLINE typename std::enable_if<!is_equal_comparable<T>::value && std::is_array<T>::value, bool>::type
-compare_equal(const T& lhs, const T& rhs)
+compare_equal(const T& lhs, const T& rhs, bool& ok)
 {
-    return compare_array_equal(lhs, rhs);
+    return compare_array_equal(lhs, rhs, ok);
 }
 
 /////////////////////////////////////////////////////////////////////////////////////////

--- a/src/rttr/detail/type/type_impl.h
+++ b/src/rttr/detail/type/type_impl.h
@@ -459,6 +459,8 @@ void type::register_comparators()
 template<typename T>
 void type::register_equal_comparator()
 {
+    static_assert(detail::has_equal_operator<T>::value, "No equal operator for given type found.");
+
     static detail::type_equal_comparator<T> cmp;
     detail::type_register::equal_comparator(type::get<T>(), &cmp);
 }
@@ -468,6 +470,8 @@ void type::register_equal_comparator()
 template<typename T>
 void type::register_less_than_comparator()
 {
+    static_assert(detail::has_less_than_operator<T>::value, "No less-than operator for given type found.");
+
     static detail::type_less_than_comparator<T> cmp;
     detail::type_register::less_than_comparator(type::get<T>(), &cmp);
 }

--- a/src/rttr/detail/variant/variant_compare.cpp
+++ b/src/rttr/detail/variant/variant_compare.cpp
@@ -68,8 +68,9 @@ bool variant_compare_equal(const variant& lhs, const type& lhs_type, const varia
 
 /////////////////////////////////////////////////////////////////////////////////////////
 
-bool variant_compare_less(const variant& lhs, const type& lhs_type, const variant& rhs, const type& rhs_type)
+bool variant_compare_less(const variant& lhs, const type& lhs_type, const variant& rhs, const type& rhs_type, bool& ok)
 {
+    ok = true;
     if (lhs_type.is_arithmetic() && rhs_type.is_arithmetic())
     {
         if (is_floating_point(lhs_type) || is_floating_point(rhs_type))
@@ -81,7 +82,7 @@ bool variant_compare_less(const variant& lhs, const type& lhs_type, const varian
     {
         variant lhs_tmp;
         if (lhs.convert(rhs_type, lhs_tmp))
-            return lhs_tmp.compare_less(rhs);
+            return lhs_tmp.compare_less(rhs, ok);
 
         if (!lhs.is_nullptr() && rhs.is_nullptr())
             return false;
@@ -91,9 +92,14 @@ bool variant_compare_less(const variant& lhs, const type& lhs_type, const varian
         bool ok2 = false;
         auto ret = (lhs.to_string(&ok1) < rhs.to_string(&ok2));
         if (ok1 && ok2)
+        {
             return ret;
+        }
         else
-            return (lhs_type < rhs_type);
+        {
+            ok = false;
+            return false;
+        }
     }
 }
 

--- a/src/rttr/detail/variant/variant_compare.cpp
+++ b/src/rttr/detail/variant/variant_compare.cpp
@@ -53,8 +53,9 @@ static RTTR_INLINE bool almost_equal(double p1, double p2)
 
 /////////////////////////////////////////////////////////////////////////////////////////
 
-bool variant_compare_equal(const variant& lhs, const type& lhs_type, const variant& rhs, const type& rhs_type)
+bool variant_compare_equal(const variant& lhs, const type& lhs_type, const variant& rhs, const type& rhs_type, bool& ok)
 {
+    ok = true;
     if (is_floating_point(lhs_type) || is_floating_point(rhs_type))
     {
         return almost_equal(lhs.to_double(), rhs.to_double());

--- a/src/rttr/detail/variant/variant_compare.h
+++ b/src/rttr/detail/variant/variant_compare.h
@@ -45,7 +45,7 @@ RTTR_API bool variant_compare_equal(const variant& lhs, const type& lhs_type, co
 
 /////////////////////////////////////////////////////////////////////////////////////////
 
-RTTR_API bool variant_compare_less(const variant& lhs, const type& lhs_type, const variant& rhs, const type& rhs_type);
+RTTR_API bool variant_compare_less(const variant& lhs, const type& lhs_type, const variant& rhs, const type& rhs_type, bool& ok);
 
 /////////////////////////////////////////////////////////////////////////////////////////
 

--- a/src/rttr/detail/variant/variant_compare.h
+++ b/src/rttr/detail/variant/variant_compare.h
@@ -41,7 +41,7 @@ namespace detail
 
 /////////////////////////////////////////////////////////////////////////////////////////
 
-RTTR_API bool variant_compare_equal(const variant& lhs, const type& lhs_type, const variant& rhs, const type& rhs_type);
+RTTR_API bool variant_compare_equal(const variant& lhs, const type& lhs_type, const variant& rhs, const type& rhs_type, bool& ok);
 
 /////////////////////////////////////////////////////////////////////////////////////////
 

--- a/src/rttr/detail/variant/variant_data_policy.h
+++ b/src/rttr/detail/variant/variant_data_policy.h
@@ -159,10 +159,10 @@ using variant_policy_func = bool (*)(variant_policy_operation, const variant_dat
 #endif
 
 #if RTTR_COMPILER == RTTR_COMPILER_MSVC && RTTR_COMP_VER <= 1800
-    #define COMPARE_LESS_PRE_PROC(lhs, rhs, result)                                     \
+    #define COMPARE_LESS_PRE_PROC(lhs, rhs, result)                           \
         compare_less_than(const_cast<typename remove_const<T>::type&>(Tp::get_value(lhs)), const_cast<typename remove_const<T>::type&>(rhs.get_value<T>()), result)
 #else
-    #define COMPARE_LESS_PRE_PROC(lhs, rhs, result)                                     \
+    #define COMPARE_LESS_PRE_PROC(lhs, rhs, result)                           \
         compare_less_than(Tp::get_value(src_data), rhs.get_value<T>(), result)
 #endif
 
@@ -360,6 +360,8 @@ struct variant_data_base_policy
                             return COMPARE_EQUAL_PRE_PROC(src_data, var_tmp, ok);
                         else if (lhs.convert(rhs_type, var_tmp))
                             return (var_tmp.compare_equal(rhs, ok));
+                        else if (rhs.is_nullptr())
+                            return is_nullptr(Tp::get_value(src_data));
                     }
                 }
 
@@ -368,24 +370,35 @@ struct variant_data_base_policy
             }
             case variant_policy_operation::COMPARE_LESS:
             {
-                const auto& param   = arg.get_value<std::tuple<const variant&, const variant&>>();
+                const auto& param   = arg.get_value<std::tuple<const variant&, const variant&, bool&>>();
                 const variant& lhs  = std::get<0>(param);
                 const variant& rhs  = std::get<1>(param);
+                bool& ok            = std::get<2>(param);
                 const type rhs_type = rhs.get_type();
                 const type lhs_type = type::get<T>();
                 int result = 0;
                 if (lhs_type == rhs_type)
                 {
-                    if (COMPARE_LESS_PRE_PROC(src_data, rhs, result))
+                    if ((ok = COMPARE_LESS_PRE_PROC(src_data, rhs, result)) == true)
                         return (result == -1 ? true : false);
                 }
                 else
                 {
-                    return variant_compare_less(lhs, lhs_type, rhs, rhs_type);
+                    return variant_compare_less(lhs, lhs_type, rhs, rhs_type, ok);
                 }
 
-                // as last try, do a string conversion
-                return (lhs.to_string() < rhs.to_string());
+                bool ok1 = false;
+                bool ok2 = false;
+                auto ret = (lhs.to_string(&ok1) < rhs.to_string(&ok2));
+                if (ok1 && ok2)
+                {
+                    ok = true;
+                    return ret;
+                }
+                else
+                {
+                    return false;
+                }
             }
         }
 
@@ -990,9 +1003,11 @@ struct RTTR_API variant_data_policy_nullptr_t
             }
             case variant_policy_operation::COMPARE_LESS:
             {
-                const auto& param   = arg.get_value<std::tuple<const variant&, const variant&>>();
+                const auto& param   = arg.get_value<std::tuple<const variant&, const variant&, bool&>>();
                 const variant& lhs  = std::get<0>(param);
                 const variant& rhs  = std::get<1>(param);
+                bool& ok            = std::get<2>(param);
+                ok = true;
                 return (lhs.is_nullptr() && !rhs.is_nullptr());
             }
         }

--- a/src/rttr/detail/variant/variant_impl.h
+++ b/src/rttr/detail/variant/variant_impl.h
@@ -80,14 +80,16 @@ RTTR_INLINE variant& variant::operator=(T&& other)
 
 RTTR_INLINE bool variant::operator==(const variant& other) const
 {
-    return compare_equal(other);
+    auto ok = false;
+    return compare_equal(other, ok);
 }
 
 /////////////////////////////////////////////////////////////////////////////////////////
 
 RTTR_INLINE bool variant::operator!=(const variant& other) const
 {
-    return !compare_equal(other);
+    auto ok = false;
+    return !compare_equal(other, ok);
 }
 
 /////////////////////////////////////////////////////////////////////////////////////////
@@ -95,6 +97,31 @@ RTTR_INLINE bool variant::operator!=(const variant& other) const
 RTTR_INLINE bool variant::operator<(const variant& other) const
 {
     return compare_less(other);
+}
+
+/////////////////////////////////////////////////////////////////////////////////////////
+
+RTTR_INLINE bool variant::operator<=(const variant& other) const
+{
+    auto ok = false;
+    return (compare_equal(other, ok) || compare_less(other));
+}
+
+/////////////////////////////////////////////////////////////////////////////////////////
+
+RTTR_INLINE bool variant::operator>=(const variant& other) const
+{
+    auto ok = false;
+    return (compare_equal(other, ok) || !compare_less(other));
+}
+
+/////////////////////////////////////////////////////////////////////////////////////////
+
+RTTR_INLINE bool variant::operator>(const variant& other) const
+{
+    auto ok = false;
+    auto cmp_result = compare_equal(other, ok);
+    return (ok && !cmp_result && !compare_less(other));
 }
 
 /////////////////////////////////////////////////////////////////////////////////////////

--- a/src/rttr/detail/variant/variant_impl.h
+++ b/src/rttr/detail/variant/variant_impl.h
@@ -96,32 +96,36 @@ RTTR_INLINE bool variant::operator!=(const variant& other) const
 
 RTTR_INLINE bool variant::operator<(const variant& other) const
 {
-    return compare_less(other);
+    bool ok = false;
+    return compare_less(other, ok);
 }
 
 /////////////////////////////////////////////////////////////////////////////////////////
 
 RTTR_INLINE bool variant::operator<=(const variant& other) const
 {
-    auto ok = false;
-    return (compare_equal(other, ok) || compare_less(other));
+    auto ok_equal = false, ok_less = false;
+    return ((compare_equal(other, ok_equal) && ok_equal) ||
+            (compare_less(other, ok_less) && ok_less));
 }
 
 /////////////////////////////////////////////////////////////////////////////////////////
 
 RTTR_INLINE bool variant::operator>=(const variant& other) const
 {
-    auto ok = false;
-    return (compare_equal(other, ok) || !compare_less(other));
+    auto ok_equal = false, ok_less = false;
+    return ( ((compare_equal(other, ok_equal) && ok_equal) ||
+              (!compare_less(other, ok_less) && ok_less))
+            && is_valid() && other.is_valid());
 }
 
 /////////////////////////////////////////////////////////////////////////////////////////
 
 RTTR_INLINE bool variant::operator>(const variant& other) const
 {
-    auto ok = false;
-    auto cmp_result = compare_equal(other, ok);
-    return (ok && !cmp_result && !compare_less(other));
+    auto ok_equal = false, ok_less = false;
+    return ((!compare_equal(other, ok_equal) && ok_equal) &&
+            (!compare_less(other, ok_less) && ok_less));
 }
 
 /////////////////////////////////////////////////////////////////////////////////////////

--- a/src/rttr/variant.cpp
+++ b/src/rttr/variant.cpp
@@ -123,9 +123,10 @@ variant& variant::operator=(variant&& other)
 
 /////////////////////////////////////////////////////////////////////////////////////////
 
-bool variant::compare_equal(const variant& other) const
+bool variant::compare_equal(const variant& other, bool& ok) const
 {
-    return m_policy(detail::variant_policy_operation::COMPARE_EQUAL, m_data, std::tie(*this, other));
+    ok = false;
+    return m_policy(detail::variant_policy_operation::COMPARE_EQUAL, m_data, std::tie(*this, other, ok));
 }
 
 /////////////////////////////////////////////////////////////////////////////////////////

--- a/src/rttr/variant.cpp
+++ b/src/rttr/variant.cpp
@@ -131,9 +131,9 @@ bool variant::compare_equal(const variant& other, bool& ok) const
 
 /////////////////////////////////////////////////////////////////////////////////////////
 
-bool variant::compare_less(const variant& other) const
+bool variant::compare_less(const variant& other, bool& ok) const
 {
-    return m_policy(detail::variant_policy_operation::COMPARE_LESS, m_data,  std::tie(*this, other));
+    return m_policy(detail::variant_policy_operation::COMPARE_LESS, m_data,  std::tie(*this, other, ok));
 }
 
 /////////////////////////////////////////////////////////////////////////////////////////

--- a/src/rttr/variant.h
+++ b/src/rttr/variant.h
@@ -255,6 +255,8 @@ class RTTR_API variant
          *         you need to register the comparison operator to the type system with \ref type::register_comparators<T>().
          *         The reason for that is, template types might define the `==` operator, but not the contained template type.
          *
+         * \note Comparability might not be available for the type stored in this variant or in \p other.
+         *
          * \see \ref variant::operator!=(const variant&) const "operator!="
          *
          * \return A boolean with value `true`, that indicates both variant's are equal, otherwise `false`.
@@ -267,6 +269,8 @@ class RTTR_API variant
          * \remark In order to use this function with template types, like `std::tuple<int, std::string>`,
          *         you need to register the comparison operator to the type system with \ref type::register_comparators<T>().
          *         The reason for that is, template types might define the `!=` operator, but not the contained template type.
+         *
+         * \note Comparability might not be available for the type stored in this variant or in \p other.
          *
          * \see \ref variant::operator==(const variant&) const "operator=="
          *
@@ -284,11 +288,58 @@ class RTTR_API variant
          *         you need to register the comparison operator to the type system with \ref type::register_comparators<T>().
          *         The reason for that is, template types might define the `<` operator, but not the contained template type.
          *
+         * \note Comparability might not be available for the type stored in this variant or in \p other.
+         *
          * \see \ref variant::operator>(const variant&) const "operator\>"
          *
          * \return A boolean with value `true`, that indicates that this variant is *less than* \p other, otherwise `false`.
          */
         RTTR_INLINE bool operator<(const variant& other) const;
+
+
+        /*!
+         * \brief Compares this variant with \p other and returns `true` if this is *less* or *equal* than \p other, otherwise returns `false`.
+         *
+         * The variant uses the *less than* and equality operator of the containing \ref get_type() "type"
+         * to get the result of the comparision.
+         *
+         * \note Comparability might not be available for the type stored in this variant or in \p other.
+         *
+         * \see \ref variant::operator<(const variant&) const "operator\<",
+         *      \ref variant::operator==(const variant&) const "operator\=="
+         *
+         * \return A boolean with value `true`, that indicates that this variant is *less* or *equal* than \p other, otherwise `false`.
+         */
+        RTTR_INLINE bool operator<=(const variant& other) const;
+
+        /*!
+         * \brief Compares this variant with \p other and returns `true` if this is *greater* or *equal* then \p other, otherwise returns `false`.
+         *
+         * The variant uses the *greater than* and equality operator of the containing \ref get_type() "type"
+         * to get the result of the comparision.
+         *
+         * \note Comparability might not be available for the type stored in this variant or in \p other.
+         *
+         * \see \ref variant::operator>(const variant&) const "operator\>",
+         *      \ref variant::operator==(const variant&) const "operator\=="
+         *
+         * \return A boolean with value `true`, that indicates that this variant is *greater* or *equal* than \p other, otherwise `false`.
+         */
+        RTTR_INLINE bool operator>=(const variant& other) const;
+
+        /*!
+         * \brief Compares this variant with \p other and returns `true` if this is *greater than* \p other, otherwise returns `false`.
+         *
+         * The variant uses the *less than* and equality operator of the containing \ref get_type() "type"
+         * to get the result of the comparision.
+         *
+         * \note Comparability might not be available for the type stored in this variant or in \p other.
+         *
+         * \see \ref variant::operator<(const variant&) const "operator\<"
+         *
+         * \return A boolean with value `true`, that indicates that this variant is *greater than* \p other, otherwise `false`.
+         */
+        RTTR_INLINE bool operator>(const variant& other) const;
 
         /*!
          * \brief When the variant contains a value, then this function will clear the content.
@@ -983,9 +1034,12 @@ class RTTR_API variant
         /*!
          * \brief Compares the containing and the given variant \p other for equality.
          *
+         *
+         * \param ok \p ok is set to `true` if the value could be compared; otherwise \p ok is set to `false`.
+         *
          * \return A boolean with value `true`, that indicates both variant's are equal, otherwise `false`.
          */
-        bool compare_equal(const variant& other) const;
+        bool compare_equal(const variant& other, bool& ok) const;
 
         /*!
          * \brief Compares the containing and the given variant \p other for less than.

--- a/src/rttr/variant.h
+++ b/src/rttr/variant.h
@@ -1034,7 +1034,6 @@ class RTTR_API variant
         /*!
          * \brief Compares the containing and the given variant \p other for equality.
          *
-         *
          * \param ok \p ok is set to `true` if the value could be compared; otherwise \p ok is set to `false`.
          *
          * \return A boolean with value `true`, that indicates both variant's are equal, otherwise `false`.
@@ -1044,9 +1043,11 @@ class RTTR_API variant
         /*!
          * \brief Compares the containing and the given variant \p other for less than.
          *
+         * \param ok \p ok is set to `true` if the value could be compared; otherwise \p ok is set to `false`.
+         *
          * \return A boolean with value `true`, that indicates this variant is less than the \p other, otherwise `false`.
          */
-        bool compare_less(const variant& other) const;
+        bool compare_less(const variant& other, bool& ok) const;
 
         /*!
          * \brief A function to check whether the contained pointer type is a `nullptr` or not.
@@ -1065,7 +1066,7 @@ class RTTR_API variant
         template<typename T, typename Tp, typename Converter>
         friend struct detail::variant_data_base_policy;
         friend struct detail::variant_data_policy_nullptr_t;
-        friend RTTR_API bool detail::variant_compare_less(const variant&, const type&, const variant&, const type&);
+        friend RTTR_API bool detail::variant_compare_less(const variant&, const type&, const variant&, const type&, bool& ok);
 
         detail::variant_data            m_data;
         detail::variant_policy_func     m_policy;

--- a/src/unit_tests/unit_tests.cmake
+++ b/src/unit_tests/unit_tests.cmake
@@ -74,6 +74,7 @@ set(SOURCE_FILES main.cpp
                  variant/variant_cmp_equal_test.cpp
                  variant/variant_cmp_less_test.cpp
                  variant/variant_cmp_greater_test.cpp
+                 variant/variant_cmp_less_or_equal.cpp
                  variant/variant_cmp_greater_or_equal.cpp
                  variant/variant_misc_test.cpp
                  variant/variant_conv_to_bool.cpp

--- a/src/unit_tests/unit_tests.cmake
+++ b/src/unit_tests/unit_tests.cmake
@@ -73,6 +73,7 @@ set(SOURCE_FILES main.cpp
                  variant/variant_ctor_test.cpp
                  variant/variant_cmp_equal_test.cpp
                  variant/variant_cmp_less_test.cpp
+                 variant/variant_cmp_greater_test.cpp
                  variant/variant_misc_test.cpp
                  variant/variant_conv_to_bool.cpp
                  variant/variant_conv_to_int8.cpp

--- a/src/unit_tests/unit_tests.cmake
+++ b/src/unit_tests/unit_tests.cmake
@@ -74,6 +74,7 @@ set(SOURCE_FILES main.cpp
                  variant/variant_cmp_equal_test.cpp
                  variant/variant_cmp_less_test.cpp
                  variant/variant_cmp_greater_test.cpp
+                 variant/variant_cmp_greater_or_equal.cpp
                  variant/variant_misc_test.cpp
                  variant/variant_conv_to_bool.cpp
                  variant/variant_conv_to_int8.cpp

--- a/src/unit_tests/variant/variant_cmp_equal_test.cpp
+++ b/src/unit_tests/variant/variant_cmp_equal_test.cpp
@@ -266,6 +266,33 @@ TEST_CASE("variant::operator==() - raw arrays", "[variant]")
 
 /////////////////////////////////////////////////////////////////////////////////////////
 
+TEST_CASE("variant::operator==() - custom type with equal operator", "[variant]")
+{
+    SECTION("equal - type_with_equal_operator")
+    {
+        type_with_equal_operator value_1 = { 1 };
+        type_with_equal_operator value_2 = { 1 };
+        variant a = value_1;
+        variant b = value_2;
+
+        CHECK((a == b) == true);
+        CHECK((a != b) == false);
+    }
+
+    SECTION("not equal - type_with_equal_operator")
+    {
+        type_with_equal_operator value_1 = { 1 };
+        type_with_equal_operator value_2 = { 2 };
+        variant a = value_1;
+        variant b = value_2;
+
+        CHECK((a == b) == false);
+        CHECK((a != b) == true);
+    }
+}
+
+/////////////////////////////////////////////////////////////////////////////////////////
+
 TEST_CASE("variant::operator==() - std::string", "[variant]")
 {
     SECTION("equal")

--- a/src/unit_tests/variant/variant_cmp_greater_or_equal.cpp
+++ b/src/unit_tests/variant/variant_cmp_greater_or_equal.cpp
@@ -33,29 +33,26 @@
 using namespace rttr;
 using namespace std;
 
-struct type_with_no_less_than_operator_2
+template<typename T>
+struct custom_compare_type
 {
-    int i;
-};
+    T i;
 
-struct type_with_less_than_operator_2 // important, other name
-{
-    int i;
+    bool operator==(const custom_compare_type<T>& other) const { return (i == other.i); }
 
-    bool operator<(const type_with_less_than_operator_2& rhs) const { return (i < rhs.i); }
-    bool operator==(const type_with_less_than_operator_2& other) const { return (i == other.i); }
+    bool operator<(const custom_compare_type<T>& other) const { return (i < other.i); }
 };
 
 /////////////////////////////////////////////////////////////////////////////////////////
 
-TEST_CASE("variant::operator>() - empty", "[variant]")
+TEST_CASE("variant::operator>=() - empty", "[variant]")
 {
     SECTION("empty type")
     {
         variant a;
         variant b;
 
-        CHECK((a > b) == false);
+        CHECK((a >= b) == false);
     }
 
     SECTION("full type lhs")
@@ -63,7 +60,7 @@ TEST_CASE("variant::operator>() - empty", "[variant]")
         variant a = 23;
         variant b;
 
-        CHECK((a > b) == false);
+        CHECK((a >= b) == false);
     }
 
     SECTION("full type rhs")
@@ -71,180 +68,140 @@ TEST_CASE("variant::operator>() - empty", "[variant]")
         variant a;
         variant b = 23;
 
-        CHECK((a > b) == false);
+        CHECK((a >= b) == false);
     }
 
 }
 
 /////////////////////////////////////////////////////////////////////////////////////////
 
-TEST_CASE("variant::operator>() - integer", "[variant]")
+TEST_CASE("variant::operator>=() - integer", "[variant]")
 {
     SECTION("equal")
     {
         variant a = static_cast<int8_t>(100);
         variant b = static_cast<int32_t>(100);
 
-        CHECK((a > b) == false);
+        CHECK((a >= b) == true);
     }
 
-    SECTION("lower > bigger")
+    SECTION("lower >= bigger")
     {
         variant a = static_cast<int8_t>(100);
         variant b = static_cast<int32_t>(10000);
 
-        CHECK((a > b) == false);
+        CHECK((a >= b) == false);
     }
 
-    SECTION("bigger > lower")
+    SECTION("bigger >= lower")
     {
         variant a = static_cast<int32_t>(10000);
         variant b = static_cast<int8_t>(100);
 
-        CHECK((a > b) == true);
+        CHECK((a >= b) == true);
     }
 
-    SECTION("lower > bigger[unsigned]")
+    SECTION("lower >= bigger[unsigned]")
     {
         variant a = static_cast<int32_t>(-10000);
         variant b = static_cast<int8_t>(100);
 
-        CHECK((a > b) == false);
+        CHECK((a >= b) == false);
     }
 }
 
 /////////////////////////////////////////////////////////////////////////////////////////
 
-TEST_CASE("variant::operator>() - float", "[variant]")
+TEST_CASE("variant::operator>=() - float", "[variant]")
 {
-    SECTION("lower > bigger")
+    SECTION("equal")
+    {
+        variant a = 123.2f;
+        variant b = 123.2f;
+
+        CHECK((a >= b) == true);
+    }
+
+    SECTION("lower >= bigger")
     {
         variant a = static_cast<int8_t>(123);
         variant b = 123.2f;
 
-        CHECK((a > b) == false);
+        CHECK((a >= b) == false);
     }
 
-    SECTION("bigger < lower")
+    SECTION("bigger >= lower")
     {
         variant a = 123.2f;
         variant b = static_cast<int8_t>(123);
 
-        CHECK((a > b) == true);
+        CHECK((a >= b) == true);
     }
 
-    SECTION("lower > bigger")
+    SECTION("lower >= bigger")
     {
         variant a = -1230.3f;
         variant b = static_cast<int8_t>(100);
 
-        CHECK((a < b) == true);
+        CHECK((a >= b) == false);
     }
 
-    SECTION("lower > bigger")
+    SECTION("lower >= bigger")
     {
         variant a = -1230.37f;
         variant b = -1230.31;
 
-        CHECK((a > b) == false);
+        CHECK((a >= b) == false);
     }
 }
 
 /////////////////////////////////////////////////////////////////////////////////////////
 
-TEST_CASE("variant::operator>() - double", "[variant]")
+TEST_CASE("variant::operator>=() - double", "[variant]")
 {
-    SECTION("lower > bigger")
+    SECTION("equal")
+    {
+        variant a = 123.2;
+        variant b = 123.2;
+
+        CHECK((a >= b) == true);
+    }
+
+    SECTION("lower >= bigger")
     {
         variant a = static_cast<int8_t>(123);
         variant b = 123.2;
 
-        CHECK((a > b) == false);
+        CHECK((a >= b) == false);
     }
 
-    SECTION("int - bigger < lower")
+    SECTION("int - bigger >= lower")
     {
         variant a = 123.2;
         variant b = static_cast<int8_t>(123);
 
-        CHECK((a > b) == true);
+        CHECK((a >= b) == true);
     }
 
-    SECTION("int UnSigned - lower < bigger")
+    SECTION("int UnSigned - lower >= bigger")
     {
         variant a = -1230.3;
         variant b = static_cast<int8_t>(100);
 
-        CHECK((a > b) == false);
-    }
-}
-
-/////////////////////////////////////////////////////////////////////////////////////////
-TEST_CASE("variant::operator>() - Non-template type", "[variant]")
-{
-    SECTION("lower < bigger")
-    {
-        variant a = type_with_less_than_operator_2{ 23 };
-        variant b = type_with_less_than_operator_2{ 42 };
-
-        CHECK((a > b) == false);
-        CHECK((b > a) == true);
+        CHECK((a >= b) == false);
     }
 }
 
 /////////////////////////////////////////////////////////////////////////////////////////
 
-TEST_CASE("variant::operator>() - template type - comparator registered", "[variant]")
-{
-    SECTION("lower < bigger")
-    {
-        variant a = std::make_tuple<int, int, int>(23, 12, 4);
-        variant b = std::make_tuple<int, int, int>(42, 44, 55);
-
-        CHECK((a > b) == false);
-        CHECK((b > a) == false);
-
-        type::register_comparators<std::tuple<int, int, int>>();
-
-        CHECK((a > b) == false);
-        CHECK((b > a) == true);
-    }
-}
-
-/////////////////////////////////////////////////////////////////////////////////////////
-
-TEST_CASE("variant::operator>() - template type - no comparator registered", "[variant]")
-{
-    SECTION("lower < bigger, use std::string comparator")
-    {
-        variant a = std::make_pair(1, 2);
-        variant b = std::make_pair(3, 4);
-
-        CHECK((a < b) == false);
-        CHECK((b < a) == false);
-
-        type::register_converter_func([](const std::pair<int, int>& p, bool& ok) -> std::string
-                                     {
-                                        ok = true;
-                                        return std::to_string(p.first);
-                                     });
-
-        CHECK((a < b) == true);
-        CHECK((b < a) == false);
-    }
-}
-
-/////////////////////////////////////////////////////////////////////////////////////////
-
-TEST_CASE("variant::operator>() - with nullptr", "[variant]")
+TEST_CASE("variant::operator>=() - with nullptr", "[variant]")
 {
     SECTION("nullptr > nullptr")
     {
         variant a = nullptr;
         variant b = nullptr;
 
-        CHECK((a > b) == false);
-        CHECK((b > a) == false);
+        CHECK((a >= b) == true);
     }
 
     SECTION("nullptr > valid")
@@ -253,7 +210,7 @@ TEST_CASE("variant::operator>() - with nullptr", "[variant]")
         variant a = nullptr;
         variant b = &obj;
 
-        CHECK((a > b) == false);
+        CHECK((a >= b) == false);
     }
 
     SECTION("valid > nullptr")
@@ -262,23 +219,22 @@ TEST_CASE("variant::operator>() - with nullptr", "[variant]")
         variant a = &obj;
         variant b = nullptr;
 
-        CHECK((a > b) == false);
+        CHECK((a >= b) == true);
     }
 }
 
 /////////////////////////////////////////////////////////////////////////////////////////
 
-TEST_CASE("variant::operator>() - raw arrays", "[variant]")
+TEST_CASE("variant::operator>=() - raw arrays", "[variant]")
 {
-    SECTION("int - pos.")
+    SECTION("int - pos. - equal")
     {
         int array[2][5]     = {{1, 2, 3, 4, 5}, {1, 2, 3, 4, 5}};
         int arrays[2][5]    = {{1, 2, 3, 4, 5}, {1, 2, 3, 4, 5}};
         variant a = array;
         variant b = arrays;
 
-        CHECK((a > b) == false);
-        CHECK((a == b) == true);
+        CHECK((a >= b) == true);
     }
 
     SECTION("int - neg.")
@@ -289,47 +245,24 @@ TEST_CASE("variant::operator>() - raw arrays", "[variant]")
         variant a = array;
         variant b = arrays;
 
-        CHECK((a > b) == true);
-        CHECK((a != b) == true);
+        CHECK((a >= b) == true);
     }
+}
 
-    SECTION("type with no less than operator")
-    {
-        type_with_no_less_than_operator_2 array[5]    = {{1}, {2}, {3}, {12}, {5}};
-        type_with_no_less_than_operator_2 arrays[5]   = {{1}, {2}, {3}, {4}, {5}};
-        variant a = array;
-        variant b = arrays;
+/////////////////////////////////////////////////////////////////////////////////////////
 
-        CHECK((a > b) == false);
-        CHECK((b > a) == false);
-    }
+TEST_CASE("variant::operator>=() - custom type", "[variant]")
+{
+    variant a = custom_compare_type<int> { 2 };
+    variant b = custom_compare_type<int> { 1 };
 
-    SECTION("greater than operator - raw array")
-    {
-        type_with_less_than_operator_2 array[5]   = {{1}, {2}, {3}, {12}, {5}};
-        type_with_less_than_operator_2 arrays[5]  = {{1}, {2}, {3}, {4}, {5}};
-        variant a = array;
-        variant b = arrays;
+    type::register_equal_comparator<custom_compare_type<int>>();
 
-        CHECK((a > b) == true);
-        CHECK((b > a) == false);
-    }
+    CHECK((a >= b) == false); // no valid comparision, because the less-than operator was not registered
 
-    SECTION("register less than operator - std::array")
-    {
-        std::array<int, 5> array_a = { {1, 2, 3, 4, 5} };
-        std::array<int, 5> array_b = { {1, 2, 0, 4, 5} };
+    type::register_less_than_comparator<custom_compare_type<int>>();
 
-        variant a = array_a;
-        variant b = array_b;
-
-        CHECK((a > b) == false);
-
-        type::register_comparators<std::array<int, 5>>();
-
-        CHECK((a > b) == true);
-    }
-
+    CHECK((a >= b) == true); // now we can compare
 }
 
 /////////////////////////////////////////////////////////////////////////////////////////

--- a/src/unit_tests/variant/variant_cmp_greater_test.cpp
+++ b/src/unit_tests/variant/variant_cmp_greater_test.cpp
@@ -317,15 +317,15 @@ TEST_CASE("variant::operator>() - raw arrays", "[variant]")
 
     SECTION("register less than operator - std::array")
     {
-        std::array<int, 5> array_a = { {1, 2, 3, 4, 5} };
-        std::array<int, 5> array_b = { {1, 2, 0, 4, 5} };
+        std::array<int, 6> array_a = { {1, 2, 3, 4, 5, 6} };
+        std::array<int, 6> array_b = { {1, 2, 0, 4, 5, 6} };
 
         variant a = array_a;
         variant b = array_b;
 
         CHECK((a > b) == false);
 
-        type::register_comparators<std::array<int, 5>>();
+        type::register_comparators<std::array<int, 6>>();
 
         CHECK((a > b) == true);
     }

--- a/src/unit_tests/variant/variant_cmp_greater_test.cpp
+++ b/src/unit_tests/variant/variant_cmp_greater_test.cpp
@@ -33,36 +33,29 @@
 using namespace rttr;
 using namespace std;
 
-struct type_with_no_less_than_operator
+struct type_with_no_less_than_operator_2
 {
     int i;
 };
 
-struct type_with_less_than_operator
+struct type_with_less_than_operator_2 // important, other name
 {
     int i;
 
-    bool operator<(const type_with_less_than_operator& rhs) const { return (i < rhs.i); }
-};
-
-template<typename T>
-struct template_type_with_less_than_operator
-{
-    T i;
-
-    bool operator<(const template_type_with_less_than_operator<T>& rhs) const { return (i < rhs.i); }
+    bool operator<(const type_with_less_than_operator_2& rhs) const { return (i < rhs.i); }
+    bool operator==(const type_with_less_than_operator_2& other) const { return (i == other.i); }
 };
 
 /////////////////////////////////////////////////////////////////////////////////////////
 
-TEST_CASE("variant::operator<() - empty", "[variant]")
+TEST_CASE("variant::operator>() - empty", "[variant]")
 {
     SECTION("empty type")
     {
         variant a;
         variant b;
 
-        CHECK((a < b) == false);
+        CHECK((a > b) == false);
     }
 
     SECTION("full type lhs")
@@ -70,7 +63,7 @@ TEST_CASE("variant::operator<() - empty", "[variant]")
         variant a = 23;
         variant b;
 
-        CHECK((a < b) == false);
+        CHECK((a > b) == false);
     }
 
     SECTION("full type rhs")
@@ -78,58 +71,58 @@ TEST_CASE("variant::operator<() - empty", "[variant]")
         variant a;
         variant b = 23;
 
-        CHECK((a < b) == false);
+        CHECK((a > b) == false);
     }
 
 }
 
 /////////////////////////////////////////////////////////////////////////////////////////
 
-TEST_CASE("variant::operator<() - integer", "[variant]")
+TEST_CASE("variant::operator>() - integer", "[variant]")
 {
     SECTION("equal")
     {
         variant a = static_cast<int8_t>(100);
         variant b = static_cast<int32_t>(100);
 
-        CHECK((a < b) == false);
+        CHECK((a > b) == false);
     }
 
-    SECTION("lower < bigger")
+    SECTION("lower > bigger")
     {
         variant a = static_cast<int8_t>(100);
         variant b = static_cast<int32_t>(10000);
 
-        CHECK((a < b) == true);
+        CHECK((a > b) == false);
     }
 
-    SECTION("bigger < lower")
+    SECTION("bigger > lower")
     {
         variant a = static_cast<int32_t>(10000);
         variant b = static_cast<int8_t>(100);
 
-        CHECK((a < b) == false);
+        CHECK((a > b) == true);
     }
 
-    SECTION("lower < bigger[unsigned]")
+    SECTION("lower > bigger[unsigned]")
     {
         variant a = static_cast<int32_t>(-10000);
         variant b = static_cast<int8_t>(100);
 
-        CHECK((a < b) == true);
+        CHECK((a > b) == false);
     }
 }
 
 /////////////////////////////////////////////////////////////////////////////////////////
 
-TEST_CASE("variant::operator<() - float", "[variant]")
+TEST_CASE("variant::operator>() - float", "[variant]")
 {
-    SECTION("lower < bigger")
+    SECTION("lower > bigger")
     {
         variant a = static_cast<int8_t>(123);
         variant b = 123.2f;
 
-        CHECK((a < b) == true);
+        CHECK((a > b) == false);
     }
 
     SECTION("bigger < lower")
@@ -137,10 +130,10 @@ TEST_CASE("variant::operator<() - float", "[variant]")
         variant a = 123.2f;
         variant b = static_cast<int8_t>(123);
 
-        CHECK((a < b) == false);
+        CHECK((a > b) == true);
     }
 
-    SECTION("lower < bigger")
+    SECTION("lower > bigger")
     {
         variant a = -1230.3f;
         variant b = static_cast<int8_t>(100);
@@ -148,25 +141,25 @@ TEST_CASE("variant::operator<() - float", "[variant]")
         CHECK((a < b) == true);
     }
 
-     SECTION("lower < bigger")
+    SECTION("lower > bigger")
     {
         variant a = -1230.37f;
         variant b = -1230.31;
 
-        CHECK((a < b) == true);
+        CHECK((a > b) == false);
     }
 }
 
 /////////////////////////////////////////////////////////////////////////////////////////
 
-TEST_CASE("variant::operator<() - double", "[variant]")
+TEST_CASE("variant::operator>() - double", "[variant]")
 {
-    SECTION("lower < bigger")
+    SECTION("lower > bigger")
     {
         variant a = static_cast<int8_t>(123);
         variant b = 123.2;
 
-        CHECK((a < b) == true);
+        CHECK((a > b) == false);
     }
 
     SECTION("int - bigger < lower")
@@ -174,7 +167,7 @@ TEST_CASE("variant::operator<() - double", "[variant]")
         variant a = 123.2;
         variant b = static_cast<int8_t>(123);
 
-        CHECK((a < b) == false);
+        CHECK((a > b) == true);
     }
 
     SECTION("int UnSigned - lower < bigger")
@@ -182,60 +175,59 @@ TEST_CASE("variant::operator<() - double", "[variant]")
         variant a = -1230.3;
         variant b = static_cast<int8_t>(100);
 
-        CHECK((a < b) == true);
+        CHECK((a > b) == false);
     }
 }
 
 /////////////////////////////////////////////////////////////////////////////////////////
-TEST_CASE("variant::operator<() - Non-template type", "[variant]")
+TEST_CASE("variant::operator>() - Non-template type", "[variant]")
 {
     SECTION("lower < bigger")
     {
-        variant a = type_with_less_than_operator{ 23 };
-        variant b = type_with_less_than_operator{ 42 };
+        variant a = type_with_less_than_operator_2{ 23 };
+        variant b = type_with_less_than_operator_2{ 42 };
 
-        CHECK((a < b) == true);
-        CHECK((b < a) == false);
+        CHECK((a > b) == false);
+        CHECK((b > a) == true);
     }
 }
 
 /////////////////////////////////////////////////////////////////////////////////////////
 
-TEST_CASE("variant::operator<() - template type - comparator registered", "[variant]")
+TEST_CASE("variant::operator>() - template type - comparator registered", "[variant]")
 {
     SECTION("lower < bigger")
     {
-        variant a = std::make_tuple<int>(23);
-        variant b = std::make_tuple<int>(42);
+        variant a = std::make_tuple<int, int, int>(23, 12, 4);
+        variant b = std::make_tuple<int, int, int>(42, 44, 55);
 
-        CHECK((a < b) == false);
-        CHECK((b < a) == false);
+        CHECK((a > b) == false);
+        CHECK((b > a) == false);
 
-        type::register_comparators<std::tuple<int>>();
+        type::register_comparators<std::tuple<int, int, int>>();
 
-        CHECK((a < b) == true);
-        CHECK((b < a) == false);
+        CHECK((a > b) == false);
+        CHECK((b > a) == true);
     }
 }
 
 /////////////////////////////////////////////////////////////////////////////////////////
 
-TEST_CASE("variant::operator<() - template type - no comparator registered", "[variant]")
+TEST_CASE("variant::operator>() - template type - no comparator registered", "[variant]")
 {
     SECTION("lower < bigger, use std::string comparator")
     {
-        variant a = std::make_tuple<int, int>(1, 2);
-        variant b = std::make_tuple<int, int>(3, 4);
+        variant a = std::make_pair(1, 2);
+        variant b = std::make_pair(3, 4);
 
         CHECK((a < b) == false);
         CHECK((b < a) == false);
 
-        type::register_converter_func(std::function<std::string(const std::tuple<int, int>& p, bool& ok)>(
-                                     [](const std::tuple<int, int>& p, bool& ok) -> std::string
+        type::register_converter_func([](const std::pair<int, int>& p, bool& ok) -> std::string
                                      {
                                         ok = true;
-                                        return "[" + std::to_string(std::get<0>(p)) + ", " + std::to_string(std::get<1>(p)) + "]";
-                                     }));
+                                        return std::to_string(p.first);
+                                     });
 
         CHECK((a < b) == true);
         CHECK((b < a) == false);
@@ -244,39 +236,39 @@ TEST_CASE("variant::operator<() - template type - no comparator registered", "[v
 
 /////////////////////////////////////////////////////////////////////////////////////////
 
-TEST_CASE("variant::operator<() - with nullptr", "[variant]")
+TEST_CASE("variant::operator>() - with nullptr", "[variant]")
 {
-    SECTION("nullptr < nullptr")
+    SECTION("nullptr > nullptr")
     {
         variant a = nullptr;
         variant b = nullptr;
 
-        CHECK((a < b) == false);
-        CHECK((b < a) == false);
+        CHECK((a > b) == false);
+        CHECK((b > a) == false);
     }
 
-    SECTION("nullptr < valid")
+    SECTION("nullptr > valid")
     {
         int obj = 12;
         variant a = nullptr;
         variant b = &obj;
 
-        CHECK((a < b) == true);
+        CHECK((a > b) == false);
     }
 
-    SECTION("valid < nullptr")
+    SECTION("valid > nullptr")
     {
         int obj = 12;
         variant a = &obj;
         variant b = nullptr;
 
-        CHECK((a < b) == false);
+        CHECK((a > b) == false);
     }
 }
 
 /////////////////////////////////////////////////////////////////////////////////////////
 
-TEST_CASE("variant::operator<() - raw arrays", "[variant]")
+TEST_CASE("variant::operator>() - raw arrays", "[variant]")
 {
     SECTION("int - pos.")
     {
@@ -285,65 +277,42 @@ TEST_CASE("variant::operator<() - raw arrays", "[variant]")
         variant a = array;
         variant b = arrays;
 
-        CHECK((a < b) == false);
+        CHECK((a > b) == false);
         CHECK((a == b) == true);
     }
 
     SECTION("int - neg.")
     {
-        int array[2][5]     = {{1, 2, 3, 4, 5}, {1, 2, 3, 0, 5}};
+        int array[2][5]     = {{1, 2, 3, 4, 5}, {1, 2, 3, 12, 5}};
         int arrays[2][5]    = {{1, 2, 3, 4, 5}, {1, 2, 3, 5, 5}};
 
         variant a = array;
         variant b = arrays;
 
-        CHECK((a < b) == true);
+        CHECK((a > b) == true);
         CHECK((a != b) == true);
     }
 
     SECTION("type with no less than operator")
     {
-        type_with_no_less_than_operator array[5]    = {{1}, {2}, {3}, {0}, {5}};
-        type_with_no_less_than_operator arrays[5]   = {{1}, {2}, {3}, {4}, {5}};
+        type_with_no_less_than_operator_2 array[5]    = {{1}, {2}, {3}, {12}, {5}};
+        type_with_no_less_than_operator_2 arrays[5]   = {{1}, {2}, {3}, {4}, {5}};
         variant a = array;
         variant b = arrays;
 
-        CHECK((a < b) == false);
+        CHECK((a > b) == false);
+        CHECK((b > a) == false);
     }
 
-    SECTION("register less than operator - raw array")
+    SECTION("greater than operator - raw array")
     {
-        type_with_less_than_operator array[5]   = {{1}, {2}, {3}, {0}, {5}};
-        type_with_less_than_operator arrays[5]  = {{1}, {2}, {3}, {4}, {5}};
+        type_with_less_than_operator_2 array[5]   = {{1}, {2}, {3}, {12}, {5}};
+        type_with_less_than_operator_2 arrays[5]  = {{1}, {2}, {3}, {4}, {5}};
         variant a = array;
         variant b = arrays;
 
-        CHECK((a < b) == true);
-    }
-
-    SECTION("register less than operator - raw array with template type")
-    {
-        {
-            template_type_with_less_than_operator<int> array[5] = { { 1 }, { 2 }, { 3 }, { 0 }, { 5 } };
-            template_type_with_less_than_operator<int> arrays[5] = { { 1 }, { 2 }, { 3 }, { 4 }, { 5 } };
-            variant a = array;
-            variant b = arrays;
-
-            CHECK((a < b) == false);
-
-            type::register_less_than_comparator<template_type_with_less_than_operator<int>>();
-
-            CHECK((a < b) == true);
-        }
-
-        {
-            template_type_with_less_than_operator<int> array[5] = { { 1 }, { 2 }, { 3 }, { 5 }, { 5 } };
-            template_type_with_less_than_operator<int> arrays[5] = { { 1 }, { 2 }, { 3 }, { 4 }, { 5 } };
-            variant a = array;
-            variant b = arrays;
-
-            CHECK((a < b) == false);
-        }
+        CHECK((a > b) == true);
+        CHECK((b > a) == false);
     }
 
     SECTION("register less than operator - std::array")
@@ -354,11 +323,11 @@ TEST_CASE("variant::operator<() - raw arrays", "[variant]")
         variant a = array_a;
         variant b = array_b;
 
-        CHECK((a < b) == false);
+     //   CHECK((a > b) == false);
 
-        type::register_less_than_comparator<std::array<int, 5>>();
+        //type::register_less_than_comparator<std::array<int, 5>>();
 
-        CHECK((a < b) == true);
+       // CHECK((a > b) == true);
     }
 
 }

--- a/src/unit_tests/variant/variant_cmp_less_or_equal.cpp
+++ b/src/unit_tests/variant/variant_cmp_less_or_equal.cpp
@@ -1,0 +1,268 @@
+/************************************************************************************
+*                                                                                   *
+*   Copyright (c) 2014, 2015 - 2017 Axel Menzel <info@rttr.org>                     *
+*                                                                                   *
+*   This file is part of RTTR (Run Time Type Reflection)                            *
+*   License: MIT License                                                            *
+*                                                                                   *
+*   Permission is hereby granted, free of charge, to any person obtaining           *
+*   a copy of this software and associated documentation files (the "Software"),    *
+*   to deal in the Software without restriction, including without limitation       *
+*   the rights to use, copy, modify, merge, publish, distribute, sublicense,        *
+*   and/or sell copies of the Software, and to permit persons to whom the           *
+*   Software is furnished to do so, subject to the following conditions:            *
+*                                                                                   *
+*   The above copyright notice and this permission notice shall be included in      *
+*   all copies or substantial portions of the Software.                             *
+*                                                                                   *
+*   THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR      *
+*   IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,        *
+*   FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE     *
+*   AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER          *
+*   LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,   *
+*   OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE   *
+*   SOFTWARE.                                                                       *
+*                                                                                   *
+*************************************************************************************/
+
+#include <catch/catch.hpp>
+
+#include <rttr/type>
+#include <tuple>
+
+using namespace rttr;
+using namespace std;
+
+template<typename T>
+struct custom_compare_type_2
+{
+    T i;
+
+    bool operator==(const custom_compare_type_2<T>& other) const { return (i == other.i); }
+
+    bool operator<(const custom_compare_type_2<T>& other) const { return (i < other.i); }
+};
+
+/////////////////////////////////////////////////////////////////////////////////////////
+
+TEST_CASE("variant::operator<=() - empty", "[variant]")
+{
+    SECTION("empty type")
+    {
+        variant a;
+        variant b;
+
+        CHECK((a <= b) == true);
+    }
+
+    SECTION("full type lhs")
+    {
+        variant a = 23;
+        variant b;
+
+        CHECK((a <= b) == false);
+    }
+
+    SECTION("full type rhs")
+    {
+        variant a;
+        variant b = 23;
+
+        CHECK((a <= b) == false);
+    }
+
+}
+
+/////////////////////////////////////////////////////////////////////////////////////////
+
+TEST_CASE("variant::operator<=() - integer", "[variant]")
+{
+    SECTION("equal")
+    {
+        variant a = static_cast<int8_t>(100);
+        variant b = static_cast<int32_t>(100);
+
+        CHECK((a <= b) == true);
+    }
+
+    SECTION("lower <= bigger")
+    {
+        variant a = static_cast<int8_t>(100);
+        variant b = static_cast<int32_t>(10000);
+
+        CHECK((a <= b) == true);
+    }
+
+    SECTION("bigger <= lower")
+    {
+        variant a = static_cast<int32_t>(10000);
+        variant b = static_cast<int8_t>(100);
+
+        CHECK((a <= b) == false);
+    }
+
+    SECTION("lower <= bigger[unsigned]")
+    {
+        variant a = static_cast<int32_t>(-10000);
+        variant b = static_cast<int8_t>(100);
+
+        CHECK((a <= b) == true);
+    }
+}
+
+/////////////////////////////////////////////////////////////////////////////////////////
+
+TEST_CASE("variant::operator<=() - float", "[variant]")
+{
+    SECTION("equal")
+    {
+        variant a = 123.2f;
+        variant b = 123.2f;
+
+        CHECK((a <= b) == true);
+    }
+
+    SECTION("lower <= bigger")
+    {
+        variant a = static_cast<int8_t>(123);
+        variant b = 123.2f;
+
+        CHECK((a <= b) == true);
+    }
+
+    SECTION("bigger <= lower")
+    {
+        variant a = 123.2f;
+        variant b = static_cast<int8_t>(123);
+
+        CHECK((a <= b) == false);
+    }
+
+    SECTION("lower <= bigger")
+    {
+        variant a = -1230.3f;
+        variant b = static_cast<int8_t>(100);
+
+        CHECK((a <= b) == true);
+    }
+
+    SECTION("lower <= bigger")
+    {
+        variant a = -1230.37f;
+        variant b = -1230.31;
+
+        CHECK((a <= b) == true);
+    }
+}
+
+/////////////////////////////////////////////////////////////////////////////////////////
+
+TEST_CASE("variant::operator<=() - double", "[variant]")
+{
+    SECTION("equal")
+    {
+        variant a = 123.2;
+        variant b = 123.2;
+
+        CHECK((a <= b) == true);
+    }
+
+    SECTION("lower <= bigger")
+    {
+        variant a = static_cast<int8_t>(123);
+        variant b = 123.2;
+
+        CHECK((a <= b) == true);
+    }
+
+    SECTION("int - bigger <= lower")
+    {
+        variant a = 123.2;
+        variant b = static_cast<int8_t>(123);
+
+        CHECK((a <= b) == false);
+    }
+
+    SECTION("int UnSigned - lower <= bigger")
+    {
+        variant a = -1230.3;
+        variant b = static_cast<int8_t>(100);
+
+        CHECK((a <= b) == true);
+    }
+}
+
+/////////////////////////////////////////////////////////////////////////////////////////
+
+TEST_CASE("variant::operator<=() - with nullptr", "[variant]")
+{
+    SECTION("nullptr > nullptr")
+    {
+        variant a = nullptr;
+        variant b = nullptr;
+
+        CHECK((a <= b) == true);
+    }
+
+    SECTION("nullptr > valid")
+    {
+        int obj = 12;
+        variant a = nullptr;
+        variant b = &obj;
+
+        CHECK((a <= b) == true);
+    }
+
+    SECTION("valid > nullptr")
+    {
+        int obj = 12;
+        variant a = &obj;
+        variant b = nullptr;
+
+        CHECK((a <= b) == false);
+    }
+}
+
+/////////////////////////////////////////////////////////////////////////////////////////
+
+TEST_CASE("variant::operator<=() - raw arrays", "[variant]")
+{
+    SECTION("int - pos. - equal")
+    {
+        int array[2][5]     = {{1, 2, 3, 4, 5}, {1, 2, 3, 4, 5}};
+        int arrays[2][5]    = {{1, 2, 3, 4, 5}, {1, 2, 3, 4, 5}};
+        variant a = array;
+        variant b = arrays;
+
+        CHECK((a <= b) == true);
+    }
+
+    SECTION("int - neg.")
+    {
+        int array[2][5]     = {{1, 2, 3, 4, 5}, {1, 2, 3, 4, 5}};
+        int arrays[2][5]    = {{1, 2, 3, 4, 5}, {1, 2, 3, 12, 5}};
+
+        variant a = array;
+        variant b = arrays;
+
+        CHECK((a <= b) == true);
+    }
+}
+
+/////////////////////////////////////////////////////////////////////////////////////////
+
+TEST_CASE("variant::operator<=() - custom type", "[variant]")
+{
+    variant a = custom_compare_type_2<int> { 2 };
+    variant b = custom_compare_type_2<int> { 2 };
+
+    type::register_less_than_comparator<custom_compare_type_2<int>>();
+
+    CHECK((a <= b) == false); // no valid comparision, because the equal operator was not registered
+
+    type::register_equal_comparator<custom_compare_type_2<int>>();
+
+    CHECK((a <= b) == true); // now we can compare
+}
+
+/////////////////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
Added operators `>`, `<=`, `>=` for variant class.
The result of the `>` operator is implicit derived from a valid registered `<` and `==` operator.
fixes #61