### PR TITLE
Bugfix class items inheritance

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -199,8 +199,9 @@ install:
       mkdir cmake && travis_retry wget --no-check-certificate --quiet -O - ${CMAKE_URL} | tar --strip-components=1 -xz -C cmake
       export PATH=${DEPS_DIR}/cmake/bin:${PATH}
     else
-      if ! brew ls --version cmake &>/dev/null; then brew install cmake; fi
+      brew upgrade cmake || brew install cmake || brew link --overwrite cmake
     fi
+  - cmake --version
   #######################################################################################
   # Install recent Doxygen
   #######################################################################################
@@ -213,7 +214,11 @@ install:
   #######################################################################################
   # Install vera++
   #######################################################################################
-  - if [[ "${CHECK_FORMATTING}" == "true" ]]; then brew install vera++; fi
+  - |
+    if [[ "${CHECK_FORMATTING}" == "true" ]]; then
+      brew upgrade pcre || brew install pcre || exit 1
+      brew upgrade vera++ || brew install vera++ || exit 1
+    fi
 
   #######################################################################################
   # Install Clang

--- a/src/rttr/detail/type/type_register.cpp
+++ b/src/rttr/detail/type/type_register.cpp
@@ -364,7 +364,13 @@ type type_register_private::register_type(type_data& info) RTTR_NOEXCEPT
 
     update_custom_name(derive_template_instance_name(info), type(&info));
 
-    return type(type_data_container[id]);
+    // when a base class type has class items, but the derived one not,
+    // we update the derived class item list
+    const auto t = type(type_data_container[id]);
+    update_class_list(t, &detail::class_data::m_properties);
+    update_class_list(t, &detail::class_data::m_methods);
+
+    return t;
 }
 
 /////////////////////////////////////////////////////////////////////////////////////////
@@ -762,7 +768,7 @@ void type_register_private::update_class_list(const type& t, T item_ptr)
 {
     // update type "t" with all items from the base classes
     auto& all_class_items = (t.m_type_data->get_class_data().*item_ptr);
-    auto item_range = get_items_for_type(t, t.m_type_data->get_class_data().*item_ptr);
+    auto item_range = get_items_for_type(t, all_class_items);
     detail::remove_cv_ref_t<decltype(all_class_items)> item_vec(item_range.begin(), item_range.end());
     all_class_items.reserve(all_class_items.size() + 1);
     all_class_items.clear(); // this will not reduce the capacity, i.e. new memory allocation may not necessary

--- a/src/unit_tests/method/method_misc_test.cpp
+++ b/src/unit_tests/method/method_misc_test.cpp
@@ -50,6 +50,20 @@ struct method_misc_test
     static void static_func() {}
 };
 
+/////////////////////////////////////////////////////////////////////////////////////////
+
+struct base_class_with_methods
+{
+    base_class_with_methods(){}
+    void some_method() {}
+
+    RTTR_ENABLE()
+};
+
+struct derived_class_without_registered_methods : base_class_with_methods
+{
+    RTTR_ENABLE(base_class_with_methods)
+};
 
 
 /////////////////////////////////////////////////////////////////////////////////////////
@@ -72,6 +86,11 @@ RTTR_REGISTRATION
             metadata("Text",  "Some funky description")
         )
         ;
+
+    registration::class_<base_class_with_methods>("base_class_with_methods")
+        .method("some_method", &base_class_with_methods::some_method);
+
+    registration::class_<derived_class_without_registered_methods>("derived_class_without_registered_methods");
 }
 
 /////////////////////////////////////////////////////////////////////////////////////////
@@ -225,3 +244,16 @@ TEST_CASE("method - default_func - NEGATIVE - get_metadata()", "[method]")
 }
 
 /////////////////////////////////////////////////////////////////////////////////////////
+
+TEST_CASE("method - check inheritance of methods", "[method]")
+{
+    // base class has registered methodes, the derived class not
+    type t = type::get<derived_class_without_registered_methods>();
+    auto meth_range = t.get_methods();
+    REQUIRE(meth_range.size() == 1);
+
+    CHECK((*meth_range.begin()).get_name() == "some_method");
+}
+
+/////////////////////////////////////////////////////////////////////////////////////////
+

--- a/src/unit_tests/property/property_class_inheritance.cpp
+++ b/src/unit_tests/property/property_class_inheritance.cpp
@@ -95,6 +95,8 @@ struct bottom : left, right, right_2
 
 }
 
+/////////////////////////////////////////////////////////////////////////////////////////
+
 struct base_prop_not_registered
 {
     base_prop_not_registered() : value(100) {}
@@ -105,6 +107,23 @@ struct derived_registered_prop : base_prop_not_registered
 {
 
 };
+
+/////////////////////////////////////////////////////////////////////////////////////////
+
+struct base_class_with_props
+{
+    base_class_with_props() : value(100) {}
+    int value;
+
+    RTTR_ENABLE()
+};
+
+struct derived_class_without_registered_props : base_class_with_props
+{
+    RTTR_ENABLE(base_class_with_props)
+};
+
+/////////////////////////////////////////////////////////////////////////////////////////
 
 static double g_name;
 
@@ -159,6 +178,12 @@ RTTR_REGISTRATION
 
     registration::class_<derived_registered_prop>("derived_registered_prop")
         .property("value", &derived_registered_prop::value);
+
+
+    registration::class_<base_class_with_props>("base_class_with_props")
+        .property("value", &base_class_with_props::value);
+
+    registration::class_<derived_class_without_registered_props>("derived_class_without_registered_props");
 }
 
 /////////////////////////////////////////////////////////////////////////////////////////
@@ -509,6 +534,18 @@ TEST_CASE("property - base class not registered", "[property]")
 
     REQUIRE(range.size() == 1);
     CHECK(*range.begin() == t_prop);
+}
+
+/////////////////////////////////////////////////////////////////////////////////////////
+
+TEST_CASE("property - check inheritance of probs", "[property]")
+{
+    // base class has registered properties, the derived class not
+    type t_prop = type::get<derived_class_without_registered_props>();
+    auto prop_range = t_prop.get_properties();
+    REQUIRE(prop_range.size() == 1);
+
+    CHECK((*prop_range.begin()).get_name() == "value");
 }
 
 /////////////////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
When the derived type has not class items(properties or methods),
then no class items were returned, altough the base class had properties.
This is now fixed.

fixes #87 