### PR TITLE
fixed rapid json compile error because of warning

### DIFF
--- a/3rd_party/rapidjson-1.1.0/rapidjson/document.h
+++ b/3rd_party/rapidjson-1.1.0/rapidjson/document.h
@@ -1,5 +1,5 @@
 // Tencent is pleased to support the open source community by making RapidJSON available.
-// 
+//
 // Copyright (C) 2015 THL A29 Limited, a Tencent company, and Milo Yip. All rights reserved.
 //
 // Licensed under the MIT License (the "License"); you may not use this file except
@@ -7,9 +7,9 @@
 //
 // http://opensource.org/licenses/MIT
 //
-// Unless required by applicable law or agreed to in writing, software distributed 
-// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR 
-// CONDITIONS OF ANY KIND, either express or implied. See the License for the 
+// Unless required by applicable law or agreed to in writing, software distributed
+// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the
 // specific language governing permissions and limitations under the License.
 
 #ifndef RAPIDJSON_DOCUMENT_H_
@@ -67,8 +67,8 @@ class GenericDocument;
     But a compiler (IBM XL C/C++ for AIX) have reported to have problem with that so it moved as a namespace scope struct.
     https://code.google.com/p/rapidjson/issues/detail?id=64
 */
-template <typename Encoding, typename Allocator> 
-struct GenericMember { 
+template <typename Encoding, typename Allocator>
+struct GenericMember {
     GenericValue<Encoding, Allocator> name;     //!< name of member (must be a string)
     GenericValue<Encoding, Allocator> value;    //!< value of member.
 };
@@ -106,8 +106,15 @@ class GenericMemberIterator
     template <bool, typename, typename> friend class GenericMemberIterator;
 
     typedef GenericMember<Encoding,Allocator> PlainType;
+#if defined(_MSC_VER)
+#pragma warning(push)
+#pragma warning(disable:4996) // std::uncaught_exception is deprecated in C++17
+#endif
     typedef typename internal::MaybeAddConst<Const,PlainType>::Type ValueType;
     typedef std::iterator<std::random_access_iterator_tag,ValueType> BaseType;
+#if defined(_MSC_VER)
+#pragma warning(pop)
+#endif
 
 public:
     //! Iterator type itself
@@ -116,13 +123,20 @@ public:
     typedef GenericMemberIterator<true,Encoding,Allocator>  ConstIterator;
     //! Non-constant iterator type
     typedef GenericMemberIterator<false,Encoding,Allocator> NonConstIterator;
-
+#if defined(_MSC_VER)
+#pragma warning(push)
+#pragma warning(disable:4996) // std::uncaught_exception is deprecated in C++17
+#endif
     //! Pointer to (const) GenericMember
     typedef typename BaseType::pointer         Pointer;
     //! Reference to (const) GenericMember
     typedef typename BaseType::reference       Reference;
     //! Signed integer type (e.g. \c ptrdiff_t)
     typedef typename BaseType::difference_type DifferenceType;
+
+#if defined(_MSC_VER)
+#pragma warning(pop)
+#endif
 
     //! Default constructor (singular value)
     /*! Creates an iterator pointing to no element.
@@ -410,7 +424,7 @@ namespace internal {
 template <typename ValueType, typename T>
 struct TypeHelper {};
 
-template<typename ValueType> 
+template<typename ValueType>
 struct TypeHelper<ValueType, bool> {
     static bool Is(const ValueType& v) { return v.IsBool(); }
     static bool Get(const ValueType& v) { return v.GetBool(); }
@@ -418,7 +432,7 @@ struct TypeHelper<ValueType, bool> {
     static ValueType& Set(ValueType& v, bool data, typename ValueType::AllocatorType&) { return v.SetBool(data); }
 };
 
-template<typename ValueType> 
+template<typename ValueType>
 struct TypeHelper<ValueType, int> {
     static bool Is(const ValueType& v) { return v.IsInt(); }
     static int Get(const ValueType& v) { return v.GetInt(); }
@@ -426,7 +440,7 @@ struct TypeHelper<ValueType, int> {
     static ValueType& Set(ValueType& v, int data, typename ValueType::AllocatorType&) { return v.SetInt(data); }
 };
 
-template<typename ValueType> 
+template<typename ValueType>
 struct TypeHelper<ValueType, unsigned> {
     static bool Is(const ValueType& v) { return v.IsUint(); }
     static unsigned Get(const ValueType& v) { return v.GetUint(); }
@@ -434,7 +448,7 @@ struct TypeHelper<ValueType, unsigned> {
     static ValueType& Set(ValueType& v, unsigned data, typename ValueType::AllocatorType&) { return v.SetUint(data); }
 };
 
-template<typename ValueType> 
+template<typename ValueType>
 struct TypeHelper<ValueType, int64_t> {
     static bool Is(const ValueType& v) { return v.IsInt64(); }
     static int64_t Get(const ValueType& v) { return v.GetInt64(); }
@@ -442,7 +456,7 @@ struct TypeHelper<ValueType, int64_t> {
     static ValueType& Set(ValueType& v, int64_t data, typename ValueType::AllocatorType&) { return v.SetInt64(data); }
 };
 
-template<typename ValueType> 
+template<typename ValueType>
 struct TypeHelper<ValueType, uint64_t> {
     static bool Is(const ValueType& v) { return v.IsUint64(); }
     static uint64_t Get(const ValueType& v) { return v.GetUint64(); }
@@ -450,7 +464,7 @@ struct TypeHelper<ValueType, uint64_t> {
     static ValueType& Set(ValueType& v, uint64_t data, typename ValueType::AllocatorType&) { return v.SetUint64(data); }
 };
 
-template<typename ValueType> 
+template<typename ValueType>
 struct TypeHelper<ValueType, double> {
     static bool Is(const ValueType& v) { return v.IsDouble(); }
     static double Get(const ValueType& v) { return v.GetDouble(); }
@@ -458,7 +472,7 @@ struct TypeHelper<ValueType, double> {
     static ValueType& Set(ValueType& v, double data, typename ValueType::AllocatorType&) { return v.SetDouble(data); }
 };
 
-template<typename ValueType> 
+template<typename ValueType>
 struct TypeHelper<ValueType, float> {
     static bool Is(const ValueType& v) { return v.IsFloat(); }
     static float Get(const ValueType& v) { return v.GetFloat(); }
@@ -466,7 +480,7 @@ struct TypeHelper<ValueType, float> {
     static ValueType& Set(ValueType& v, float data, typename ValueType::AllocatorType&) { return v.SetFloat(data); }
 };
 
-template<typename ValueType> 
+template<typename ValueType>
 struct TypeHelper<ValueType, const typename ValueType::Ch*> {
     typedef const typename ValueType::Ch* StringType;
     static bool Is(const ValueType& v) { return v.IsString(); }
@@ -476,7 +490,7 @@ struct TypeHelper<ValueType, const typename ValueType::Ch*> {
 };
 
 #if RAPIDJSON_HAS_STDSTRING
-template<typename ValueType> 
+template<typename ValueType>
 struct TypeHelper<ValueType, std::basic_string<typename ValueType::Ch> > {
     typedef std::basic_string<typename ValueType::Ch> StringType;
     static bool Is(const ValueType& v) { return v.IsString(); }
@@ -485,7 +499,7 @@ struct TypeHelper<ValueType, std::basic_string<typename ValueType::Ch> > {
 };
 #endif
 
-template<typename ValueType> 
+template<typename ValueType>
 struct TypeHelper<ValueType, typename ValueType::Array> {
     typedef typename ValueType::Array ArrayType;
     static bool Is(const ValueType& v) { return v.IsArray(); }
@@ -494,14 +508,14 @@ struct TypeHelper<ValueType, typename ValueType::Array> {
     static ValueType& Set(ValueType& v, ArrayType data, typename ValueType::AllocatorType&) { return v = data; }
 };
 
-template<typename ValueType> 
+template<typename ValueType>
 struct TypeHelper<ValueType, typename ValueType::ConstArray> {
     typedef typename ValueType::ConstArray ArrayType;
     static bool Is(const ValueType& v) { return v.IsArray(); }
     static ArrayType Get(const ValueType& v) { return v.GetArray(); }
 };
 
-template<typename ValueType> 
+template<typename ValueType>
 struct TypeHelper<ValueType, typename ValueType::Object> {
     typedef typename ValueType::Object ObjectType;
     static bool Is(const ValueType& v) { return v.IsObject(); }
@@ -510,7 +524,7 @@ struct TypeHelper<ValueType, typename ValueType::Object> {
     static ValueType& Set(ValueType& v, ObjectType data, typename ValueType::AllocatorType&) { v = data; }
 };
 
-template<typename ValueType> 
+template<typename ValueType>
 struct TypeHelper<ValueType, typename ValueType::ConstObject> {
     typedef typename ValueType::ConstObject ObjectType;
     static bool Is(const ValueType& v) { return v.IsObject(); }
@@ -536,7 +550,7 @@ template <bool, typename> class GenericObject;
     \tparam Encoding    Encoding of the value. (Even non-string values need to have the same encoding in a document)
     \tparam Allocator   Allocator type for allocating memory of object, array and string.
 */
-template <typename Encoding, typename Allocator = MemoryPoolAllocator<> > 
+template <typename Encoding, typename Allocator = MemoryPoolAllocator<> >
 class GenericValue {
 public:
     //! Name-value pair in an object.
@@ -638,7 +652,7 @@ public:
 
     //! Constructor for unsigned value.
     explicit GenericValue(unsigned u) RAPIDJSON_NOEXCEPT : data_() {
-        data_.n.u64 = u; 
+        data_.n.u64 = u;
         data_.f.flags = (u & 0x80000000) ? kNumberUintFlag : (kNumberUintFlag | kIntFlag | kInt64Flag);
     }
 
@@ -857,14 +871,14 @@ public:
         switch (GetType()) {
         case kObjectType: // Warning: O(n^2) inner-loop
             if (data_.o.size != rhs.data_.o.size)
-                return false;           
+                return false;
             for (ConstMemberIterator lhsMemberItr = MemberBegin(); lhsMemberItr != MemberEnd(); ++lhsMemberItr) {
                 typename RhsType::ConstMemberIterator rhsMemberItr = rhs.FindMember(lhsMemberItr->name);
                 if (rhsMemberItr == rhs.MemberEnd() || lhsMemberItr->value != rhsMemberItr->value)
                     return false;
             }
             return true;
-            
+
         case kArrayType:
             if (data_.a.size != rhs.data_.a.size)
                 return false;
@@ -1335,7 +1349,7 @@ public:
         \note Linear time complexity.
     */
     void RemoveAllMembers() {
-        RAPIDJSON_ASSERT(IsObject()); 
+        RAPIDJSON_ASSERT(IsObject());
         for (MemberIterator m = MemberBegin(); m != MemberEnd(); ++m)
             m->~Member();
         data_.o.size = 0;
@@ -1481,7 +1495,7 @@ public:
         \note Linear time complexity.
     */
     void Clear() {
-        RAPIDJSON_ASSERT(IsArray()); 
+        RAPIDJSON_ASSERT(IsArray());
         GenericValue* e = GetElementsPointer();
         for (GenericValue* v = e; v != e + data_.a.size; ++v)
             v->~GenericValue();
@@ -1628,7 +1642,7 @@ public:
         RAPIDJSON_ASSERT(last <= End());
         ValueIterator pos = Begin() + (first - Begin());
         for (ValueIterator itr = pos; itr != last; ++itr)
-            itr->~GenericValue();       
+            itr->~GenericValue();
         std::memmove(pos, last, static_cast<size_t>(End() - last) * sizeof(GenericValue));
         data_.a.size -= static_cast<SizeType>(last - first);
         return pos;
@@ -1687,7 +1701,7 @@ public:
 
     //! Set this value as a string without copying source string.
     /*! This version has better performance with supplied length, and also support string containing null character.
-        \param s source string pointer. 
+        \param s source string pointer.
         \param length The length of source string, excluding the trailing null terminator.
         \return The value itself for fluent API.
         \post IsString() == true && GetString() == s && GetStringLength() == length
@@ -1704,7 +1718,7 @@ public:
 
     //! Set this value as a string by copying from source string.
     /*! This version has better performance with supplied length, and also support string containing null character.
-        \param s source string. 
+        \param s source string.
         \param length The length of source string, excluding the trailing null terminator.
         \param allocator Allocator for allocating copied buffer. Commonly use GenericDocument::GetAllocator().
         \return The value itself for fluent API.
@@ -1713,7 +1727,7 @@ public:
     GenericValue& SetString(const Ch* s, SizeType length, Allocator& allocator) { this->~GenericValue(); SetStringRaw(StringRef(s, length), allocator); return *this; }
 
     //! Set this value as a string by copying from source string.
-    /*! \param s source string. 
+    /*! \param s source string.
         \param allocator Allocator for allocating copied buffer. Commonly use GenericDocument::GetAllocator().
         \return The value itself for fluent API.
         \post IsString() == true && GetString() != s && strcmp(GetString(),s) == 0 && GetStringLength() == length
@@ -1790,10 +1804,10 @@ public:
                 if (RAPIDJSON_UNLIKELY(!v->Accept(handler)))
                     return false;
             return handler.EndArray(data_.a.size);
-    
+
         case kStringType:
             return handler.String(GetString(), GetStringLength(), (data_.f.flags & kCopyFlag) != 0);
-    
+
         default:
             RAPIDJSON_ASSERT(GetType() == kNumberType);
             if (IsDouble())         return handler.Double(data_.n.d);
@@ -2010,7 +2024,7 @@ private:
 typedef GenericValue<UTF8<> > Value;
 
 ///////////////////////////////////////////////////////////////////////////////
-// GenericDocument 
+// GenericDocument
 
 //! A document for parsing JSON text as DOM.
 /*!
@@ -2042,12 +2056,12 @@ public:
     }
 
     //! Constructor
-    /*! Creates an empty document which type is Null. 
+    /*! Creates an empty document which type is Null.
         \param allocator        Optional allocator for allocating memory.
         \param stackCapacity    Optional initial capacity of stack in bytes.
         \param stackAllocator   Optional allocator for allocating memory for stack.
     */
-    GenericDocument(Allocator* allocator = 0, size_t stackCapacity = kDefaultStackCapacity, StackAllocator* stackAllocator = 0) : 
+    GenericDocument(Allocator* allocator = 0, size_t stackCapacity = kDefaultStackCapacity, StackAllocator* stackAllocator = 0) :
         allocator_(allocator), ownAllocator_(0), stack_(stackAllocator, stackCapacity), parseResult_()
     {
         if (!allocator_)
@@ -2253,7 +2267,7 @@ public:
     GenericDocument& Parse(const Ch* str, size_t length) {
         return Parse<parseFlags, Encoding>(str, length);
     }
-    
+
     GenericDocument& Parse(const Ch* str, size_t length) {
         return Parse<kParseDefaultFlags>(str, length);
     }
@@ -2273,7 +2287,7 @@ public:
     GenericDocument& Parse(const std::basic_string<Ch>& str) {
         return Parse<kParseDefaultFlags>(str);
     }
-#endif // RAPIDJSON_HAS_STDSTRING    
+#endif // RAPIDJSON_HAS_STDSTRING
 
     //!@}
 
@@ -2338,16 +2352,16 @@ public:
     bool Uint64(uint64_t i) { new (stack_.template Push<ValueType>()) ValueType(i); return true; }
     bool Double(double d) { new (stack_.template Push<ValueType>()) ValueType(d); return true; }
 
-    bool RawNumber(const Ch* str, SizeType length, bool copy) { 
-        if (copy) 
+    bool RawNumber(const Ch* str, SizeType length, bool copy) {
+        if (copy)
             new (stack_.template Push<ValueType>()) ValueType(str, length, GetAllocator());
         else
             new (stack_.template Push<ValueType>()) ValueType(str, length);
         return true;
     }
 
-    bool String(const Ch* str, SizeType length, bool copy) { 
-        if (copy) 
+    bool String(const Ch* str, SizeType length, bool copy) {
+        if (copy)
             new (stack_.template Push<ValueType>()) ValueType(str, length, GetAllocator());
         else
             new (stack_.template Push<ValueType>()) ValueType(str, length);
@@ -2355,7 +2369,7 @@ public:
     }
 
     bool StartObject() { new (stack_.template Push<ValueType>()) ValueType(kObjectType); return true; }
-    
+
     bool Key(const Ch* str, SizeType length, bool copy) { return String(str, length, copy); }
 
     bool EndObject(SizeType memberCount) {
@@ -2365,7 +2379,7 @@ public:
     }
 
     bool StartArray() { new (stack_.template Push<ValueType>()) ValueType(kArrayType); return true; }
-    
+
     bool EndArray(SizeType elementCount) {
         ValueType* elements = stack_.template Pop<ValueType>(elementCount);
         stack_.template Top<ValueType>()->SetArrayRaw(elements, elementCount, GetAllocator());

--- a/CMake/config.cmake
+++ b/CMake/config.cmake
@@ -119,12 +119,6 @@ enable_rtti(BUILD_WITH_RTTI)
 get_latest_supported_cxx(CXX_STANDARD)
 set(MAX_CXX_STANDARD ${CXX_STANDARD})
 
-if(MSVC)
-    if (${CXX_STANDARD} EQUAL 17 AND CMAKE_CXX_COMPILER_VERSION VERSION_LESS "19.12.25835.0")
-        set(MAX_CXX_STANDARD 14) # downgrade, because RTTR can't be compiled atm. with c++17 flag (template error)
-    endif()
-endif()
-
 message(STATUS "using C++: ${MAX_CXX_STANDARD}")
 
 # RelWithDepInfo should have the same option like the Release build

--- a/CMake/utility.cmake
+++ b/CMake/utility.cmake
@@ -540,8 +540,8 @@ function(get_latest_supported_cxx CXX_STANDARD)
 
     include(CheckCXXSourceCompiles)
 
-    check_cxx_source_compiles(
-                              "#include <type_traits>
+    check_cxx_source_compiles("
+                              #include <type_traits>
                               typedef void F();
                               typedef void G() noexcept;
                               
@@ -554,8 +554,8 @@ function(get_latest_supported_cxx CXX_STANDARD)
                               "
                               HAS_NO_EXCEPT_TYPE_SIGNATURE_SUPPORT)
 
-    check_cxx_source_compiles(
-                              "#include <type_traits>
+    check_cxx_source_compiles("
+                              #include <type_traits>
                               struct foo { void func() const noexcept {} };
                               template<typename T>
                               void test_func(T)
@@ -576,8 +576,27 @@ function(get_latest_supported_cxx CXX_STANDARD)
                               int main() { }
                               "
                               HAS_CXX_CONSTEXPR)
+                              
+    check_cxx_source_compiles( "
+                               #include <type_traits>
+                               template<typename T>
+                               struct template_type_trait : std::false_type {};
+                               
+                               template<template < bool > class T, bool N>
+                               struct template_type_trait<T<N>> : std::true_type {};
+                               
+                               template<template <std::size_t> class T, std::size_t N>
+                               struct template_type_trait<T<N>> : std::true_type {};
+                               
+                               template<std::size_t T>
+                               struct bar{};
+                               
+                               int main() { static bool foo = template_type_trait<bar<100>>::value;}
+                               "
+                               HAS_PARTIAL_SPECIALIZATION_FOR_ARRAYS)
 
-    if (HAS_NO_EXCEPT_TYPE_SIGNATURE_SUPPORT AND HAS_STL_NO_EXCEPT_TYPE_SIGNATURE_SUPPORT)
+    if (HAS_NO_EXCEPT_TYPE_SIGNATURE_SUPPORT AND HAS_STL_NO_EXCEPT_TYPE_SIGNATURE_SUPPORT AND
+        HAS_PARTIAL_SPECIALIZATION_FOR_ARRAYS)
         set(MAX_CXX_STD 17)
     else()
         if (HAS_CXX_CONSTEXPR)


### PR DESCRIPTION
added cmake check for C++17 bug in MSVC compiler:
https://developercommunity.visualstudio.com/content/problem/192396/more-than-one-partial-specialization-compile-error.html
C++17 automatically disabled when using MSVC for the moment,
with a new update it will be enabled automatically

#118 