### PR TITLE
fixed not honored raw arrays in variant_sequential_view

### DIFF
--- a/src/rttr/detail/variant_associative_view/variant_associative_view_creator.h
+++ b/src/rttr/detail/variant_associative_view/variant_associative_view_creator.h
@@ -47,12 +47,12 @@ using can_create_associative_view = std::integral_constant<bool, is_associative_
 
 /////////////////////////////////////////////////////////////////////////////////////////
 
-template<typename T, typename Tp = typename std::decay<T>::type>
-enable_if_t<can_create_associative_view<Tp>::value, variant_associative_view_private>
+template<typename T>
+enable_if_t<can_create_associative_view<T>::value, variant_associative_view_private>
 create_variant_associative_view(T&& value);
 
-template<typename T, typename Tp = typename std::decay<T>::type>
-enable_if_t<!can_create_associative_view<Tp>::value, variant_associative_view_private>
+template<typename T>
+enable_if_t<!can_create_associative_view<T>::value, variant_associative_view_private>
 create_variant_associative_view(T&& value);
 
 /////////////////////////////////////////////////////////////////////////////////////////

--- a/src/rttr/detail/variant_associative_view/variant_associative_view_creator_impl.h
+++ b/src/rttr/detail/variant_associative_view/variant_associative_view_creator_impl.h
@@ -37,8 +37,8 @@ namespace detail
 
 /////////////////////////////////////////////////////////////////////////////////////////
 
-template<typename T, typename Tp>
-enable_if_t<can_create_associative_view<Tp>::value, variant_associative_view_private>
+template<typename T>
+enable_if_t<can_create_associative_view<T>::value, variant_associative_view_private>
 create_variant_associative_view(T&& value)
 {
     return variant_associative_view_private(wrapped_raw_addressof(value));
@@ -46,8 +46,8 @@ create_variant_associative_view(T&& value)
 
 /////////////////////////////////////////////////////////////////////////////////////////
 
-template<typename T, typename Tp>
-enable_if_t<!can_create_associative_view<Tp>::value, variant_associative_view_private>
+template<typename T>
+enable_if_t<!can_create_associative_view<T>::value, variant_associative_view_private>
 create_variant_associative_view(T&& value)
 {
     return variant_associative_view_private();

--- a/src/rttr/detail/variant_sequential_view/variant_sequential_view_creator.h
+++ b/src/rttr/detail/variant_sequential_view/variant_sequential_view_creator.h
@@ -47,12 +47,12 @@ using can_create_sequential_view = std::integral_constant<bool, is_sequential_co
 
 /////////////////////////////////////////////////////////////////////////////////////////
 
-template<typename T, typename Tp = typename std::decay<T>::type>
-enable_if_t<can_create_sequential_view<Tp>::value, variant_sequential_view_private>
+template<typename T>
+enable_if_t<can_create_sequential_view<T>::value, variant_sequential_view_private>
 create_variant_sequential_view(T&& value);
 
-template<typename T, typename Tp = typename std::decay<T>::type>
-enable_if_t<!can_create_sequential_view<Tp>::value, variant_sequential_view_private>
+template<typename T>
+enable_if_t<!can_create_sequential_view<T>::value, variant_sequential_view_private>
 create_variant_sequential_view(T&& value);
 
 /////////////////////////////////////////////////////////////////////////////////////////

--- a/src/rttr/detail/variant_sequential_view/variant_sequential_view_creator_impl.h
+++ b/src/rttr/detail/variant_sequential_view/variant_sequential_view_creator_impl.h
@@ -37,8 +37,8 @@ namespace detail
 
 /////////////////////////////////////////////////////////////////////////////////////////
 
-template<typename T, typename Tp>
-enable_if_t<can_create_sequential_view<Tp>::value, variant_sequential_view_private>
+template<typename T>
+enable_if_t<can_create_sequential_view<T>::value, variant_sequential_view_private>
 create_variant_sequential_view(T&& value)
 {
     return variant_sequential_view_private(wrapped_raw_addressof(value));
@@ -46,8 +46,8 @@ create_variant_sequential_view(T&& value)
 
 /////////////////////////////////////////////////////////////////////////////////////////
 
-template<typename T, typename Tp>
-enable_if_t<!can_create_sequential_view<Tp>::value, variant_sequential_view_private>
+template<typename T>
+enable_if_t<!can_create_sequential_view<T>::value, variant_sequential_view_private>
 create_variant_sequential_view(T&& value)
 {
     return variant_sequential_view_private();

--- a/src/unit_tests/variant_sequential_view/variant_sequential_view_test.cpp
+++ b/src/unit_tests/variant_sequential_view/variant_sequential_view_test.cpp
@@ -161,16 +161,20 @@ TEST_CASE("variant::is_sequential_container", "[variant_sequential_view]")
     {
         variant var;
         CHECK(var.is_sequential_container() == false);
+        CHECK(var.create_sequential_view().is_valid() == false);
 
         var = 23;
         CHECK(var.is_sequential_container() == false);
+        CHECK(var.create_sequential_view().is_valid() == false);
 
         var = std::set<int>({1, 2, 3});
         CHECK(var.is_sequential_container() == false);
+        CHECK(var.create_sequential_view().is_valid() == false);
 
         auto set = std::set<int>({ 1, 2, 3 });
         var = std::ref(set);
         CHECK(var.is_sequential_container() == false);
+        CHECK(var.create_sequential_view().is_valid() == false);
     }
 
 
@@ -180,12 +184,15 @@ TEST_CASE("variant::is_sequential_container", "[variant_sequential_view]")
 
         variant var = vec;
         CHECK(var.is_sequential_container() == true);
+        CHECK(var.create_sequential_view().is_valid() == true);
 
         var = std::ref(vec);
         CHECK(var.is_sequential_container() == true);
+        CHECK(var.create_sequential_view().is_valid() == true);
 
         var = &vec;
         CHECK(var.is_sequential_container() == true);
+        CHECK(var.create_sequential_view().is_valid() == true);
     }
 
     SECTION("valid - std::vector<bool>")
@@ -194,6 +201,7 @@ TEST_CASE("variant::is_sequential_container", "[variant_sequential_view]")
 
         variant var = vec;
         CHECK(var.is_sequential_container() == true);
+        CHECK(var.create_sequential_view().is_valid() == true);
     }
 
     SECTION("valid - std::list")
@@ -202,6 +210,7 @@ TEST_CASE("variant::is_sequential_container", "[variant_sequential_view]")
 
         variant var = list;
         CHECK(var.is_sequential_container() == true);
+        CHECK(var.create_sequential_view().is_valid() == true);
     }
 
     SECTION("valid - std::deque")
@@ -210,6 +219,7 @@ TEST_CASE("variant::is_sequential_container", "[variant_sequential_view]")
 
         variant var = deque;
         CHECK(var.is_sequential_container() == true);
+        CHECK(var.create_sequential_view().is_valid() == true);
     }
 
     SECTION("valid - std::array")
@@ -218,6 +228,7 @@ TEST_CASE("variant::is_sequential_container", "[variant_sequential_view]")
 
         variant var = array;
         CHECK(var.is_sequential_container() == true);
+        CHECK(var.create_sequential_view().is_valid() == true);
     }
 
     SECTION("valid - std::initializer_list")
@@ -226,6 +237,7 @@ TEST_CASE("variant::is_sequential_container", "[variant_sequential_view]")
 
         variant var = init_list;
         CHECK(var.is_sequential_container() == true);
+        CHECK(var.create_sequential_view().is_valid() == true);
     }
 
     SECTION("valid - raw array")
@@ -234,6 +246,16 @@ TEST_CASE("variant::is_sequential_container", "[variant_sequential_view]")
 
         variant var = array;
         CHECK(var.is_sequential_container() == true);
+        CHECK(var.create_sequential_view().is_valid() == true);
+    }
+
+    SECTION("valid - raw array ptr")
+    {
+        int array[3] = {1, 2, 3};
+
+        variant var = &array;
+        CHECK(var.is_sequential_container() == true);
+        CHECK(var.create_sequential_view().is_valid() == true);
     }
 
 }
@@ -455,6 +477,7 @@ TEST_CASE("variant_sequential_view::set_size()", "[variant_sequential_view]")
         int obj[2] = { 0, 0 };
         variant var = obj;
         auto view = var.create_sequential_view();
+        CHECK(view.is_valid()   == true);
         CHECK(view.set_size(10) == false);
     }
 
@@ -508,6 +531,15 @@ TEST_CASE("variant_sequential_view::insert()", "[variant_sequential_view]")
 
         CHECK(itr == view.end());
         CHECK(view.get_size() == 5);
+    }
+
+    SECTION("raw array")
+    {
+        int obj[2] = { 0, 0 };
+        variant var = obj;
+        auto view = var.create_sequential_view();
+
+        CHECK(view.insert(view.begin(), 12) == view.end());
     }
 
     SECTION("const std::vector")


### PR DESCRIPTION
Only pointer types were correctly recognized. Because of using std::decay<T>.
Now the "is_sequential_container()" & "create_sequential_view()" function are using the same type.

Fixed this also for variant_associative_view. No test provided because, raw arrays are not associative container.

Added some more tests