### PR TITLE
Feature add variant_cast

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 ####################################################################################
 #                                                                                  #
-#  Copyright (c) 2014, 2015 - 2017 Axel Menzel <info@rttr.org>                     #
+#  Copyright (c) 2014 - 2018 Axel Menzel <info@rttr.org>                           #
 #                                                                                  #
 #  This file is part of RTTR (Run Time Type Reflection)                            #
 #  License: MIT License                                                            #

--- a/src/rttr/detail/misc/std_type_traits.h
+++ b/src/rttr/detail/misc/std_type_traits.h
@@ -248,6 +248,9 @@ using decay_t = typename std::decay<T>::type;
 template<typename T>
 using add_const_t = typename std::add_const<T>::type;
 
+template<typename T>
+using add_lvalue_reference_t = typename std::add_lvalue_reference<T>::type;
+
 /////////////////////////////////////////////////////////////////////////////////////
 
 } // end namespace detail

--- a/src/rttr/detail/variant/variant_data_policy.h
+++ b/src/rttr/detail/variant/variant_data_policy.h
@@ -652,7 +652,7 @@ struct RTTR_API variant_data_policy_empty
             }
             case variant_policy_operation::GET_VALUE:
             {
-                arg.get_value<void*>() = nullptr;
+                arg.get_value<const void*>() = nullptr;
                 break;
             }
             case variant_policy_operation::GET_TYPE:
@@ -767,7 +767,7 @@ struct RTTR_API variant_data_policy_void
             }
             case variant_policy_operation::GET_VALUE:
             {
-                arg.get_value<void*>() = nullptr;
+                arg.get_value<const void*>() = nullptr;
                 break;
             }
             case variant_policy_operation::GET_TYPE:

--- a/src/rttr/detail/variant/variant_impl.h
+++ b/src/rttr/detail/variant/variant_impl.h
@@ -141,7 +141,7 @@ RTTR_INLINE T& variant::get_value()
     using namespace detail;
     auto result = unsafe_variant_cast<variant_t<T>>(this);
 
-    using ref_type = conditional_t<std::is_reference<T>::value, T, std::add_lvalue_reference_t<T>>;
+    using ref_type = conditional_t<std::is_reference<T>::value, T, add_lvalue_reference_t<T>>;
     return *result;
 }
 
@@ -153,7 +153,7 @@ RTTR_INLINE const T& variant::get_value() const
     using namespace detail;
     auto result = unsafe_variant_cast<variant_t<T>>(this);
 
-    using ref_type = conditional_t<std::is_reference<T>::value, T, std::add_lvalue_reference_t<T>>;
+    using ref_type = conditional_t<std::is_reference<T>::value, T, add_lvalue_reference_t<T>>;
     return *result;
 }
 
@@ -446,7 +446,7 @@ RTTR_INLINE T variant_cast(const variant& operand)
 
     auto result = unsafe_variant_cast<variant_t<T>>(&operand);
 
-    using ref_type = conditional_t<std::is_reference<T>::value, T, std::add_lvalue_reference_t<T>>;
+    using ref_type = conditional_t<std::is_reference<T>::value, T, add_lvalue_reference_t<T>>;
     return static_cast<ref_type>(*result);
 }
 
@@ -461,7 +461,7 @@ RTTR_INLINE T variant_cast(variant& operand)
 
     auto result = unsafe_variant_cast<variant_t<T>>(&operand);
 
-    using ref_type = conditional_t<std::is_reference<T>::value, T, std::add_lvalue_reference_t<T>>;
+    using ref_type = conditional_t<std::is_reference<T>::value, T, add_lvalue_reference_t<T>>;
     return static_cast<ref_type>(*result);
 }
 

--- a/src/rttr/detail/variant/variant_impl.h
+++ b/src/rttr/detail/variant/variant_impl.h
@@ -40,6 +40,11 @@
 
 namespace rttr
 {
+namespace detail
+{
+template<typename T>
+using variant_t = detail::remove_cv_t<detail::remove_reference_t<T>>;
+}
 
 /////////////////////////////////////////////////////////////////////////////////////////
 
@@ -131,12 +136,25 @@ RTTR_INLINE bool variant::operator>(const variant& other) const
 /////////////////////////////////////////////////////////////////////////////////////////
 
 template<typename T>
+RTTR_INLINE T& variant::get_value()
+{
+    using namespace detail;
+    auto result = unsafe_variant_cast<variant_t<T>>(this);
+
+    using ref_type = conditional_t<std::is_reference<T>::value, T, std::add_lvalue_reference_t<T>>;
+    return *result;
+}
+
+/////////////////////////////////////////////////////////////////////////////////////////
+
+template<typename T>
 RTTR_INLINE const T& variant::get_value() const
 {
-    const void* value;
-    m_policy(detail::variant_policy_operation::GET_VALUE, m_data, value);
-    using nonRef = detail::remove_cv_t<T>;
-    return *reinterpret_cast<const nonRef*>(value);
+    using namespace detail;
+    auto result = unsafe_variant_cast<variant_t<T>>(this);
+
+    using ref_type = conditional_t<std::is_reference<T>::value, T, std::add_lvalue_reference_t<T>>;
+    return *result;
 }
 
 /////////////////////////////////////////////////////////////////////////////////////////
@@ -388,6 +406,93 @@ template<typename T>
 RTTR_INLINE T variant::convert(bool* ok) const
 {
     return convert_impl<T>(ok);
+}
+
+/////////////////////////////////////////////////////////////////////////////////////////
+/////////////////////////////////////////////////////////////////////////////////////////
+/////////////////////////////////////////////////////////////////////////////////////////
+
+namespace detail
+{
+
+/////////////////////////////////////////////////////////////////////////////////////////
+
+template<class T>
+RTTR_INLINE T* unsafe_variant_cast(variant* operand) RTTR_NOEXCEPT
+{
+    const void* value;
+    operand->m_policy(detail::variant_policy_operation::GET_VALUE, operand->m_data, value);
+    return reinterpret_cast<T*>(const_cast<void*>(value));
+}
+
+/////////////////////////////////////////////////////////////////////////////////////////
+
+template<class T>
+RTTR_INLINE const T* unsafe_variant_cast(const variant* operand) RTTR_NOEXCEPT
+{
+    return unsafe_variant_cast<const T>(const_cast<variant*>(operand));
+}
+
+} // end namespace detail
+
+/////////////////////////////////////////////////////////////////////////////////////////
+
+template<class T>
+RTTR_INLINE T variant_cast(const variant& operand)
+{
+    using namespace detail;
+    static_assert(std::is_constructible<T, const variant_t<T>&>::value,
+                  "variant_cast<T>(variant&) requires T to be constructible from const remove_cv_t<remove_reference_t<T>>&");
+
+    auto result = unsafe_variant_cast<variant_t<T>>(&operand);
+
+    using ref_type = conditional_t<std::is_reference<T>::value, T, std::add_lvalue_reference_t<T>>;
+    return static_cast<ref_type>(*result);
+}
+
+/////////////////////////////////////////////////////////////////////////////////////////
+
+template<class T>
+RTTR_INLINE T variant_cast(variant& operand)
+{
+    using namespace detail;
+    static_assert(std::is_constructible<T, variant_t<T>&>::value,
+                  "variant_cast<T>(variant&) requires T to be constructible from remove_cv_t<remove_reference_t<T>>&");
+
+    auto result = unsafe_variant_cast<variant_t<T>>(&operand);
+
+    using ref_type = conditional_t<std::is_reference<T>::value, T, std::add_lvalue_reference_t<T>>;
+    return static_cast<ref_type>(*result);
+}
+
+/////////////////////////////////////////////////////////////////////////////////////////
+
+template<class T>
+RTTR_INLINE T variant_cast(variant&& operand)
+{
+    using namespace detail;
+    static_assert(std::is_constructible<T, variant_t<T>>::value,
+                  "variant_cast<T>(variant&&) requires T to be constructible from remove_cv_t<remove_reference_t<T>>");
+    auto result = unsafe_variant_cast<variant_t<T>>(&operand);
+    return std::move(*result);
+}
+
+/////////////////////////////////////////////////////////////////////////////////////////
+
+template<class T>
+RTTR_INLINE T* variant_cast(variant* operand) RTTR_NOEXCEPT
+{
+    using namespace detail;
+    return (type::get<T>() == operand->get_type()) ?
+            unsafe_variant_cast<T>(operand) : nullptr;
+}
+
+/////////////////////////////////////////////////////////////////////////////////////////
+
+template<class T>
+RTTR_INLINE const T* variant_cast(const variant* operand) RTTR_NOEXCEPT
+{
+    return variant_cast<T>(const_cast<variant*>(operand));
 }
 
 /////////////////////////////////////////////////////////////////////////////////////////

--- a/src/rttr/detail/variant/variant_impl.h
+++ b/src/rttr/detail/variant/variant_impl.h
@@ -141,7 +141,6 @@ RTTR_INLINE T& variant::get_value()
     using namespace detail;
     auto result = unsafe_variant_cast<variant_t<T>>(this);
 
-    using ref_type = conditional_t<std::is_reference<T>::value, T, add_lvalue_reference_t<T>>;
     return *result;
 }
 
@@ -153,7 +152,6 @@ RTTR_INLINE const T& variant::get_value() const
     using namespace detail;
     auto result = unsafe_variant_cast<variant_t<T>>(this);
 
-    using ref_type = conditional_t<std::is_reference<T>::value, T, add_lvalue_reference_t<T>>;
     return *result;
 }
 

--- a/src/rttr/detail/variant/variant_impl.h
+++ b/src/rttr/detail/variant/variant_impl.h
@@ -43,7 +43,7 @@ namespace rttr
 namespace detail
 {
 template<typename T>
-using variant_t = detail::remove_cv_t<detail::remove_reference_t<T>>;
+using variant_t = remove_cv_t<remove_reference_t<T>>;
 }
 
 /////////////////////////////////////////////////////////////////////////////////////////

--- a/src/rttr/variant.h
+++ b/src/rttr/variant.h
@@ -1150,7 +1150,7 @@ T variant_cast(variant& operand);
  *  variant var = std::string("hello world");
  *  std::string& a = variant_cast<std::string&>(var);
  *  std:string b = variant_cast<std::string>(std::move(var)); // move the value to 'b'
- *  std::cout << "a: " << a << std::endl; // is now empty
+ *  std::cout << "a: " << a << std::endl; // is now empty (nothing to print)
  *  std::cout << "b: " << b << std::endl; // prints "hello world"
  *
  * \endcode
@@ -1169,10 +1169,10 @@ T variant_cast(variant&& operand);
  * \code{.cpp}
  *
  *  variant var = std::string("hello world");
- *  std:string* a = variant_cast<std::string>(&var);  // performs an internal type check and returns extracts the value by reference
+ *  std:string* a = variant_cast<std::string>(&var);  // performs an internal type check and returns the value by reference
  *  int* b        = variant_cast<int>(&var);
- *  std::cout << "a valid: " << a != nullptr << std::endl;
- *  std::cout << "b valid: " << b != nullptr << std::endl;
+ *  std::cout << "a valid: " << a != nullptr << std::endl;  // prints "1"
+ *  std::cout << "b valid: " << b != nullptr << std::endl;  // prints "0"
  * \endcode
  *
  * \return A valid pointer, when the containing type is of type \p T; otherwise a `nullptr`.
@@ -1188,10 +1188,10 @@ const T* variant_cast(const variant* operand) RTTR_NOEXCEPT;
  * \code{.cpp}
  *
  *  variant var = std::string("hello world");
- *  std:string* a = variant_cast<std::string>(&var);  // performs an internal type check and returns extracts the value by reference
+ *  std:string* a = variant_cast<std::string>(&var);  // performs an internal type check and returns the value by reference
  *  int* b        = variant_cast<int>(&var);
- *  std::cout << "a valid: " << a != nullptr << std::endl;
- *  std::cout << "b valid: " << b != nullptr << std::endl;
+ *  std::cout << "a valid: " << a != nullptr << std::endl;  // prints "1"
+ *  std::cout << "b valid: " << b != nullptr << std::endl;  // prints "0"
  * \endcode
  *
  * \return A valid pointer, when the containing type is of type \p T; otherwise a `nullptr`.

--- a/src/unit_tests/unit_tests.cmake
+++ b/src/unit_tests/unit_tests.cmake
@@ -78,6 +78,7 @@ set(SOURCE_FILES main.cpp
                  variant/variant_cmp_less_or_equal.cpp
                  variant/variant_cmp_greater_or_equal.cpp
                  variant/variant_misc_test.cpp
+                 variant/variant_cast_test.cpp
                  variant/variant_conv_to_bool.cpp
                  variant/variant_conv_to_int8.cpp
                  variant/variant_conv_to_int16.cpp

--- a/src/unit_tests/variant/variant_cast_test.cpp
+++ b/src/unit_tests/variant/variant_cast_test.cpp
@@ -53,7 +53,7 @@ TEST_CASE("variant - variant_cast<T>(variant*)", "[variant]")
 
         CHECK(value != nullptr);
 
-        using value_t = std::remove_reference_t<decltype(value)>;
+        using value_t = detail::remove_reference_t<decltype(value)>;
         static_assert(std::is_same<decltype(value), int*>::value, "Must be integer pointer type!");
 
         REQUIRE(value != nullptr);
@@ -100,7 +100,7 @@ TEST_CASE("variant - variant_cast<T>(const variant*)", "[variant]")
 
         CHECK(value != nullptr);
 
-        using value_t = std::remove_reference_t<decltype(value)>;
+        using value_t = detail::remove_reference_t<decltype(value)>;
         static_assert(std::is_same<decltype(value), const int*>::value, "Must be integer pointer type!");
 
         REQUIRE(value != nullptr);

--- a/src/unit_tests/variant/variant_cast_test.cpp
+++ b/src/unit_tests/variant/variant_cast_test.cpp
@@ -53,7 +53,6 @@ TEST_CASE("variant - variant_cast<T>(variant*)", "[variant]")
 
         CHECK(value != nullptr);
 
-        using value_t = detail::remove_reference_t<decltype(value)>;
         static_assert(std::is_same<decltype(value), int*>::value, "Must be integer pointer type!");
 
         REQUIRE(value != nullptr);
@@ -100,7 +99,6 @@ TEST_CASE("variant - variant_cast<T>(const variant*)", "[variant]")
 
         CHECK(value != nullptr);
 
-        using value_t = detail::remove_reference_t<decltype(value)>;
         static_assert(std::is_same<decltype(value), const int*>::value, "Must be integer pointer type!");
 
         REQUIRE(value != nullptr);
@@ -232,6 +230,7 @@ TEST_CASE("variant - variant_cast<T>(variant&&)", "[variant]")
         CHECK(move_count == 1);
         moveable_class m2 = variant_cast<moveable_class>(std::move(var));
         CHECK(move_count == 2);
+        CHECK(m2.value == 12); // to avoid not used variable warning
 
         moveable_class&& m3 = variant_cast<moveable_class&&>(std::move(var));
         CHECK(move_count == 2); // will not move

--- a/src/unit_tests/variant/variant_cast_test.cpp
+++ b/src/unit_tests/variant/variant_cast_test.cpp
@@ -1,0 +1,232 @@
+/************************************************************************************
+*                                                                                   *
+*   Copyright (c) 2014, 2015 - 2017 Axel Menzel <info@rttr.org>                     *
+*                                                                                   *
+*   This file is part of RTTR (Run Time Type Reflection)                            *
+*   License: MIT License                                                            *
+*                                                                                   *
+*   Permission is hereby granted, free of charge, to any person obtaining           *
+*   a copy of this software and associated documentation files (the "Software"),    *
+*   to deal in the Software without restriction, including without limitation       *
+*   the rights to use, copy, modify, merge, publish, distribute, sublicense,        *
+*   and/or sell copies of the Software, and to permit persons to whom the           *
+*   Software is furnished to do so, subject to the following conditions:            *
+*                                                                                   *
+*   The above copyright notice and this permission notice shall be included in      *
+*   all copies or substantial portions of the Software.                             *
+*                                                                                   *
+*   THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR      *
+*   IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,        *
+*   FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE     *
+*   AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER          *
+*   LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,   *
+*   OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE   *
+*   SOFTWARE.                                                                       *
+*                                                                                   *
+*************************************************************************************/
+
+#include <catch/catch.hpp>
+#include <iostream>
+#include <rttr/type>
+
+using namespace rttr;
+
+
+/////////////////////////////////////////////////////////////////////////////////////////
+
+TEST_CASE("variant - variant_cast<T>(variant*)", "[variant]")
+{
+    SECTION("empty cast")
+    {
+        variant var;
+
+        auto value = variant_cast<int>(&var);
+
+        CHECK(value == nullptr);
+    }
+
+    SECTION("valid cast")
+    {
+        variant var = 12;
+
+        auto value = variant_cast<int>(&var);
+
+        CHECK(value != nullptr);
+
+        using value_t = std::remove_reference_t<decltype(value)>;
+        static_assert(std::is_same<decltype(value), int*>::value, "Must be integer pointer type!");
+
+        REQUIRE(value != nullptr);
+        CHECK(*value == 12);
+    }
+
+    SECTION("invalid cast")
+    {
+        variant var = 12;
+
+        auto value = variant_cast<bool>(&var);
+        CHECK(value == nullptr); // nullptr, because not of type "int"
+    }
+}
+
+/////////////////////////////////////////////////////////////////////////////////////////
+
+TEST_CASE("variant - variant_cast<T>(const variant*)", "[variant]")
+{
+    SECTION("empty cast")
+    {
+        const variant var;
+
+        auto value = variant_cast<int>(&var);
+
+        CHECK(value == nullptr);
+    }
+
+    SECTION("valid cast")
+    {
+        const variant var = 12;
+
+        auto value = variant_cast<int>(&var);
+
+        CHECK(value != nullptr);
+
+        using value_t = std::remove_reference_t<decltype(value)>;
+        static_assert(std::is_same<decltype(value), const int*>::value, "Must be integer pointer type!");
+
+        REQUIRE(value != nullptr);
+        CHECK(*value == 12);
+    }
+
+    SECTION("invalid cast")
+    {
+        const variant var = 12;
+
+        auto value = variant_cast<bool>(&var);
+        CHECK(value == nullptr); // nullptr, because not of type "int"
+    }
+}
+
+/////////////////////////////////////////////////////////////////////////////////////////
+
+TEST_CASE("variant - variant_cast<T>(variant&)", "[variant]")
+{
+    SECTION("by value")
+    {
+        variant var = 12;
+
+        REQUIRE(var.get_type() == type::get<int>());
+
+        auto value = variant_cast<int>(var);
+        CHECK(value == 12);
+        using value_t = decltype(value);
+        static_assert(!std::is_reference<value_t>::value, "Must be value type!");
+    }
+
+    SECTION("by reference")
+    {
+        variant var = 12;
+
+        REQUIRE(var.get_type() == type::get<int>());
+
+        auto& value = variant_cast<int&>(var);
+        CHECK(value == 12);
+
+        using value_t = decltype(value);
+        static_assert(std::is_reference<value_t>::value, "Must be reference type!");
+    }
+
+    SECTION("move from")
+    {
+        std::string text = "cat";
+        variant var = text;
+
+        REQUIRE(var.get_type() == type::get<std::string>());
+
+        std::string s;
+        s = std::move(variant_cast<std::string&>(var));
+        CHECK(s == text);
+        CHECK(variant_cast<std::string&>(var).empty() == true);
+
+        std::string text2 = "hello";
+        variant_cast<std::string&>(var) = std::move(text2);
+        CHECK(variant_cast<std::string&>(var) == "hello");
+    }
+}
+
+/////////////////////////////////////////////////////////////////////////////////////////
+
+TEST_CASE("variant - variant_cast<T>(const variant&)", "[variant]")
+{
+    SECTION("by value")
+    {
+        const variant var = 12;
+
+        CHECK(var.get_type() == type::get<int>());
+
+        auto value = variant_cast<const int>(var);
+        CHECK(value == 12);
+        using value_t = decltype(value);
+        static_assert(!std::is_reference<value_t>::value, "Must be value type!");
+    }
+
+    SECTION("by reference")
+    {
+        std::string text = "cat";
+        const variant var = text;
+
+        CHECK(var.get_type() == type::get<std::string>());
+
+        auto& value = variant_cast<const std::string&>(var);
+        CHECK(value == text);
+
+        using value_t = decltype(value);
+        static_assert(std::is_reference<value_t>::value, "Must be reference type!");
+        static_assert(std::is_const<detail::remove_reference_t<value_t>>::value, "Must be const-reference type!");
+    }
+}
+
+/////////////////////////////////////////////////////////////////////////////////////////
+
+static int move_count = 0;
+
+struct moveable_class
+  {
+    moveable_class(moveable_class&&)
+    {
+      ++move_count;
+    }
+    moveable_class() {}
+    moveable_class(const moveable_class&) {}
+    int value = 12;
+};
+
+/////////////////////////////////////////////////////////////////////////////////////////
+
+TEST_CASE("variant - variant_cast<T>(variant&&)", "[variant]")
+{
+    SECTION("move test - string")
+    {
+        std::string text = "cat";
+        variant var = text;
+
+        CHECK(var.get_type() == type::get<std::string>());
+
+        auto value = variant_cast<std::string>(std::move(var));
+        CHECK(value == text);
+    }
+
+    SECTION("move test")
+    {
+        moveable_class obj;
+        variant var = std::move(obj);
+        CHECK(move_count == 1);
+        moveable_class m2 = variant_cast<moveable_class>(std::move(var));
+        CHECK(move_count == 2);
+
+        moveable_class&& m3 = variant_cast<moveable_class&&>(std::move(var));
+        CHECK(move_count == 3);
+        CHECK(m3.value == 12); // to avoid not used variable warning
+    }
+}
+
+/////////////////////////////////////////////////////////////////////////////////////////

--- a/src/unit_tests/variant/variant_cast_test.cpp
+++ b/src/unit_tests/variant/variant_cast_test.cpp
@@ -60,6 +60,16 @@ TEST_CASE("variant - variant_cast<T>(variant*)", "[variant]")
         CHECK(*value == 12);
     }
 
+    SECTION("valid cast - pointer")
+    {
+        int obj = 12;
+        variant var = &obj;
+
+        auto value = variant_cast<int*>(&var);
+        REQUIRE(value != nullptr);
+        CHECK(**value == 12);
+    }
+
     SECTION("invalid cast")
     {
         variant var = 12;
@@ -224,7 +234,7 @@ TEST_CASE("variant - variant_cast<T>(variant&&)", "[variant]")
         CHECK(move_count == 2);
 
         moveable_class&& m3 = variant_cast<moveable_class&&>(std::move(var));
-        CHECK(move_count == 3);
+        CHECK(move_count == 2); // will not move
         CHECK(m3.value == 12); // to avoid not used variable warning
     }
 }

--- a/src/unit_tests/variant/variant_misc_test.cpp
+++ b/src/unit_tests/variant/variant_misc_test.cpp
@@ -101,6 +101,36 @@ TEST_CASE("variant - swap", "[variant]")
 
 /////////////////////////////////////////////////////////////////////////////////////////
 
+TEST_CASE("variant - get_value()", "[variant]")
+{
+    SECTION("check get_value() non-const version")
+    {
+        std::string text = "hello world";
+        variant var = text;
+
+        auto& value = var.get_value<std::string>();
+        value = "world";
+        using value_t = std::remove_reference_t<decltype(value)>;
+
+        static_assert(!std::is_const<value_t>::value, "Provide non-const getter!");
+
+        CHECK(var.get_value<std::string>() == "world");
+    }
+
+    SECTION("check get_value() const version")
+    {
+        std::string text = "hello world";
+        const variant var = text;
+
+        auto& value = var.get_value<std::string>();
+
+        using value_t = std::remove_reference_t<decltype(value)>;
+        static_assert(std::is_const<value_t>::value, "Provide non-const getter!");
+    }
+}
+
+/////////////////////////////////////////////////////////////////////////////////////////
+
 TEST_CASE("variant - get_wrapped_value", "[variant]")
 {
     int foo = 12;

--- a/src/unit_tests/variant/variant_misc_test.cpp
+++ b/src/unit_tests/variant/variant_misc_test.cpp
@@ -110,7 +110,7 @@ TEST_CASE("variant - get_value()", "[variant]")
 
         auto& value = var.get_value<std::string>();
         value = "world";
-        using value_t = std::remove_reference_t<decltype(value)>;
+        using value_t = detail::remove_reference_t<decltype(value)>;
 
         static_assert(!std::is_const<value_t>::value, "Provide non-const getter!");
 
@@ -124,8 +124,9 @@ TEST_CASE("variant - get_value()", "[variant]")
 
         auto& value = var.get_value<std::string>();
 
-        using value_t = std::remove_reference_t<decltype(value)>;
+        using value_t = detail::remove_reference_t<decltype(value)>;
         static_assert(std::is_const<value_t>::value, "Provide non-const getter!");
+        CHECK(value == text);
     }
 }
 


### PR DESCRIPTION
Added global "variant_cast" method

Added 4 overloads of the method "variant_cast"
In order to move values out, to return values by reference
or to return a pointer to the underlying values, when the type does match:

template<class T>
T variant_cast(variant&& operand);

template<class T>
T variant_cast(variant& operand);

template<class T>
T variant_cast(const variant& operand);

template<class T>
const T* variant_cast(const variant* operand) RTTR_NOEXCEPT;

template<class T>
T* variant_cast(variant* operand) RTTR_NOEXCEPT;

Additionally:
- added non-const version of variant::get_value()
- fixed copy-right year in root CMakeLists.txt file

Fixes #108