### PR TITLE
fixed typo int "constructor" class

### DIFF
--- a/src/examples/json_serialization/from_json.cpp
+++ b/src/examples/json_serialization/from_json.cpp
@@ -131,7 +131,7 @@ variant extract_value(Value::MemberIterator& itr, const type& t)
             constructor ctor = t.get_constructor();
             for (auto& item : t.get_constructors())
             {
-                if (item.get_instanciated_type() == t)
+                if (item.get_instantiated_type() == t)
                     ctor = item;
             }
             extracted_value = ctor.invoke();

--- a/src/rttr/constructor.cpp
+++ b/src/rttr/constructor.cpp
@@ -85,9 +85,9 @@ access_levels constructor::get_access_level() const RTTR_NOEXCEPT
 
 /////////////////////////////////////////////////////////////////////////////////////////
 
-type constructor::get_instanciated_type() const RTTR_NOEXCEPT
+type constructor::get_instantiated_type() const RTTR_NOEXCEPT
 {
-    return m_wrapper->get_instanciated_type();
+    return m_wrapper->get_instantiated_type();
 }
 
 /////////////////////////////////////////////////////////////////////////////////////////

--- a/src/rttr/constructor.h
+++ b/src/rttr/constructor.h
@@ -60,7 +60,7 @@ class constructor_wrapper_base;
  *
  * Meta Information
  * ----------------
- * A \ref constructor has a signature (\ref get_signature()) and instantiate exactly one type (\ref get_instanciated_type()).
+ * A \ref constructor has a signature (\ref get_signature()) and instantiate exactly one type (\ref get_instantiated_type()).
  * With \ref get_parameter_infos() you retrieve all information of the parameters for this constructor.
  * When the \ref constructor was declared inside a class, then \ref get_declaring_type() can be used to obtain the type of this class.
  *
@@ -117,7 +117,7 @@ class RTTR_API constructor
          *
          * \return The instantiated type.
          */
-        type get_instanciated_type() const RTTR_NOEXCEPT;
+        type get_instantiated_type() const RTTR_NOEXCEPT;
 
         /*!
          * \brief Returns the \ref type of the class or struct that declares this \ref constructor.
@@ -154,7 +154,7 @@ class RTTR_API constructor
         variant get_metadata(const variant& key) const;
 
         /*!
-         * \brief Invokes the constructor of type returned by \ref get_instanciated_type().
+         * \brief Invokes the constructor of type returned by \ref get_instantiated_type().
          *        The instance will always be created on the heap and will be returned as variant object.
          *
          * \remark Returns an invalid \ref variant object (see \ref variant::is_valid), when the arguments does
@@ -162,12 +162,12 @@ class RTTR_API constructor
          *
          * \see get_parameter_infos()
          *
-         * \return An instance of the type \ref get_instanciated_type().
+         * \return An instance of the type \ref get_instantiated_type().
          */
         variant invoke() const;
 
         /*!
-         * \brief Invokes the constructor of type returned by \ref get_instanciated_type().
+         * \brief Invokes the constructor of type returned by \ref get_instantiated_type().
          *        The instance will always be created on the heap and will be returned as variant object.
          *
          * \remark The given argument type has to match **exactly** the type of the underling constructor parameter,
@@ -176,12 +176,12 @@ class RTTR_API constructor
          *
          * \see get_parameter_infos()
          *
-         * \return An instance of the type \ref get_instanciated_type().
+         * \return An instance of the type \ref get_instantiated_type().
          */
         variant invoke(argument arg1) const;
 
         /*!
-         * \brief Invokes the constructor of type returned by \ref get_instanciated_type().
+         * \brief Invokes the constructor of type returned by \ref get_instantiated_type().
          *        The instance will always be created on the heap and will be returned as variant object.
          *
          * \remark The given argument type has to match **exactly** the type of the underling constructor parameter,
@@ -190,12 +190,12 @@ class RTTR_API constructor
          *
          * \see get_parameter_infos()
          *
-         * \return An instance of the type \ref get_instanciated_type().
+         * \return An instance of the type \ref get_instantiated_type().
          */
         variant invoke(argument arg1, argument arg2) const;
 
         /*!
-         * \brief Invokes the constructor of type returned by \ref get_instanciated_type().
+         * \brief Invokes the constructor of type returned by \ref get_instantiated_type().
          *        The instance will always be created on the heap and will be returned as variant object.
          *
          * \remark The given argument type has to match **exactly** the type of the underling constructor parameter,
@@ -204,12 +204,12 @@ class RTTR_API constructor
          *
          * \see get_parameter_infos()
          *
-         * \return An instance of the type \ref get_instanciated_type().
+         * \return An instance of the type \ref get_instantiated_type().
          */
         variant invoke(argument arg1, argument arg2, argument arg3) const;
 
         /*!
-         * \brief Invokes the constructor of type returned by \ref get_instanciated_type().
+         * \brief Invokes the constructor of type returned by \ref get_instantiated_type().
          *        The instance will always be created on the heap and will be returned as variant object.
          *
          * \remark The given argument type has to match **exactly** the type of the underling constructor parameter,
@@ -218,12 +218,12 @@ class RTTR_API constructor
          *
          * \see get_parameter_infos()
          *
-         * \return An instance of the type \ref get_instanciated_type().
+         * \return An instance of the type \ref get_instantiated_type().
          */
         variant invoke(argument arg1, argument arg2, argument arg3, argument arg4) const;
 
         /*!
-         * \brief Invokes the constructor of type returned by \ref get_instanciated_type().
+         * \brief Invokes the constructor of type returned by \ref get_instantiated_type().
          *        The instance will always be created on the heap and will be returned as variant object.
          *
          * \remark The given argument type has to match **exactly** the type of the underling constructor parameter,
@@ -232,13 +232,13 @@ class RTTR_API constructor
          *
          * \see get_parameter_infos()
          *
-         * \return An instance of the type \ref get_instanciated_type().
+         * \return An instance of the type \ref get_instantiated_type().
          */
         variant invoke(argument arg1, argument arg2, argument arg3, argument arg4,
                        argument arg5) const;
 
         /*!
-         * \brief Invokes the constructor of type returned by \ref get_instanciated_type().
+         * \brief Invokes the constructor of type returned by \ref get_instantiated_type().
          *        The instance will always be created on the heap and will be returned as variant object.
          *
          * \remark The given argument type has to match **exactly** the type of the underling constructor parameter,
@@ -247,13 +247,13 @@ class RTTR_API constructor
          *
          * \see get_parameter_infos()
          *
-         * \return An instance of the type \ref get_instanciated_type().
+         * \return An instance of the type \ref get_instantiated_type().
          */
         variant invoke(argument arg1, argument arg2, argument arg3, argument arg4,
                        argument arg5, argument arg6) const;
 
         /*!
-         * \brief Invokes the constructor of type returned by \ref get_instanciated_type().
+         * \brief Invokes the constructor of type returned by \ref get_instantiated_type().
          *        The instance will always be created on the heap and will be returned as variant object.
          *         Use this method when you need to instantiate a constructor with more then 6 parameters.
          *
@@ -264,7 +264,7 @@ class RTTR_API constructor
          *
          * \see get_parameter_infos()
          *
-         * \return An instance of the type \ref get_instanciated_type().
+         * \return An instance of the type \ref get_instantiated_type().
          */
         variant invoke_variadic(std::vector<argument> args) const;
 

--- a/src/rttr/detail/constructor/constructor_wrapper.h
+++ b/src/rttr/detail/constructor/constructor_wrapper.h
@@ -88,7 +88,7 @@ class constructor_wrapper<Class_Type, class_ctor, Acc_Level, Policy,
 
         bool is_valid()                     const RTTR_NOEXCEPT { return true; }
         access_levels get_access_level()    const RTTR_NOEXCEPT { return Acc_Level; }
-        type get_instanciated_type()        const RTTR_NOEXCEPT { return type::get<instanciated_type>(); }
+        type get_instantiated_type()        const RTTR_NOEXCEPT { return type::get<instanciated_type>(); }
         type get_declaring_type()           const RTTR_NOEXCEPT { return type::get<typename raw_type<Class_Type>::type>(); }
 
         RTTR_INLINE std::vector<bool> get_is_reference_impl(std::true_type)     const RTTR_NOEXCEPT { return {std::is_reference<Ctor_Args>::value...}; }
@@ -196,7 +196,7 @@ class constructor_wrapper<ClassType, return_func, Acc_Level, Policy,
 
         bool is_valid()                                     const RTTR_NOEXCEPT { return true; }
         access_levels get_access_level()                    const RTTR_NOEXCEPT { return Acc_Level; }
-        type get_instanciated_type()                        const RTTR_NOEXCEPT { return type::get<instanciated_type>();                  }
+        type get_instantiated_type()                        const RTTR_NOEXCEPT { return type::get<instanciated_type>();                  }
         type get_declaring_type()                           const RTTR_NOEXCEPT { return type::get<typename raw_type<ClassType>::type>(); }
         std::vector<bool> get_is_reference()                const RTTR_NOEXCEPT { return method_accessor<F, Policy>::get_is_reference();  }
         std::vector<bool> get_is_const()                    const RTTR_NOEXCEPT { return method_accessor<F, Policy>::get_is_const();      }
@@ -267,7 +267,7 @@ class constructor_wrapper<Class_Type, class_ctor, Acc_Level, Policy,
 
         bool is_valid()                     const RTTR_NOEXCEPT { return true; }
         access_levels get_access_level()    const RTTR_NOEXCEPT { return Acc_Level; }
-        type get_instanciated_type()        const RTTR_NOEXCEPT { return type::get<instanciated_type>(); }
+        type get_instantiated_type()        const RTTR_NOEXCEPT { return type::get<instanciated_type>(); }
         type get_declaring_type()           const RTTR_NOEXCEPT { return type::get<typename raw_type<Class_Type>::type>(); }
 
         RTTR_INLINE std::vector<bool> get_is_reference_impl(std::true_type)     const RTTR_NOEXCEPT { return {std::is_reference<Ctor_Args>::value...}; }
@@ -368,7 +368,7 @@ class constructor_wrapper<ClassType, return_func, Acc_Level, Policy,
 
         bool is_valid()                                     const RTTR_NOEXCEPT { return true; }
         access_levels get_access_level()                    const RTTR_NOEXCEPT { return Acc_Level; }
-        type get_instanciated_type()                        const RTTR_NOEXCEPT { return type::get<instanciated_type>();                  }
+        type get_instantiated_type()                        const RTTR_NOEXCEPT { return type::get<instanciated_type>();                  }
         type get_declaring_type()                           const RTTR_NOEXCEPT { return type::get<typename raw_type<ClassType>::type>(); }
         std::vector<bool> get_is_reference()                const RTTR_NOEXCEPT { return method_accessor<F, Policy>::get_is_reference();  }
         std::vector<bool> get_is_const()                    const RTTR_NOEXCEPT { return method_accessor<F, Policy>::get_is_const();      }

--- a/src/rttr/detail/constructor/constructor_wrapper_base.cpp
+++ b/src/rttr/detail/constructor/constructor_wrapper_base.cpp
@@ -55,7 +55,7 @@ constructor_wrapper_base::~constructor_wrapper_base()
 void constructor_wrapper_base::init() RTTR_NOEXCEPT
 {
     create_signature_string();
-    get_instanciated_type();
+    get_instantiated_type();
     get_parameter_infos();
 }
 
@@ -73,11 +73,11 @@ void constructor_wrapper_base::create_signature_string() RTTR_NOEXCEPT
     if (!m_signature.empty())
         return;
 
-    if (!get_instanciated_type())
+    if (!get_instantiated_type())
         return;
 
     auto param_info_list = get_parameter_infos();
-    m_signature = get_instanciated_type().get_raw_type().get_name().to_string() + "( ";
+    m_signature = get_instantiated_type().get_raw_type().get_name().to_string() + "( ";
     auto ref_list = get_is_reference();
     auto const_list = get_is_const();
     for (const auto& param : param_info_list)
@@ -117,7 +117,7 @@ access_levels constructor_wrapper_base::get_access_level() const RTTR_NOEXCEPT
 
 /////////////////////////////////////////////////////////////////////////////////////////
 
-type constructor_wrapper_base::get_instanciated_type() const RTTR_NOEXCEPT
+type constructor_wrapper_base::get_instantiated_type() const RTTR_NOEXCEPT
 {
     return get_invalid_type();
 }

--- a/src/rttr/detail/constructor/constructor_wrapper_base.h
+++ b/src/rttr/detail/constructor/constructor_wrapper_base.h
@@ -63,7 +63,7 @@ class RTTR_API constructor_wrapper_base
         virtual bool is_valid() const RTTR_NOEXCEPT;
         virtual type get_declaring_type() const RTTR_NOEXCEPT;
         virtual access_levels get_access_level() const RTTR_NOEXCEPT;
-        virtual type get_instanciated_type() const RTTR_NOEXCEPT;
+        virtual type get_instantiated_type() const RTTR_NOEXCEPT;
         virtual std::vector<bool> get_is_reference() const RTTR_NOEXCEPT;
         virtual std::vector<bool> get_is_const() const RTTR_NOEXCEPT;
         virtual array_range<parameter_info> get_parameter_infos() const RTTR_NOEXCEPT;

--- a/src/rttr/detail/constructor/constructor_wrapper_defaults.h
+++ b/src/rttr/detail/constructor/constructor_wrapper_defaults.h
@@ -78,7 +78,7 @@ class constructor_wrapper<Class_Type, class_ctor, Acc_Level, Policy, Metadata_Co
         }
 
         bool is_valid()                  const RTTR_NOEXCEPT { return true; }
-        type get_instanciated_type()     const RTTR_NOEXCEPT { return type::get<instanciated_type>(); }
+        type get_instantiated_type()     const RTTR_NOEXCEPT { return type::get<instanciated_type>(); }
         type get_declaring_type()        const RTTR_NOEXCEPT { return type::get<typename raw_type<Class_Type>::type>(); }
         access_levels get_access_level() const RTTR_NOEXCEPT { return Acc_Level; }
 
@@ -169,7 +169,7 @@ class constructor_wrapper<ClassType, return_func, Acc_Level, Policy,
 
         bool is_valid()                                     const RTTR_NOEXCEPT { return true; }
         access_levels get_access_level()                    const RTTR_NOEXCEPT { return Acc_Level; }
-        type get_instanciated_type()                        const RTTR_NOEXCEPT { return type::get<instanciated_type>();                      }
+        type get_instantiated_type()                        const RTTR_NOEXCEPT { return type::get<instanciated_type>();                      }
         type get_declaring_type()                           const RTTR_NOEXCEPT { return type::get<typename raw_type<ClassType>::type>();     }
         std::vector<bool> get_is_reference()                const RTTR_NOEXCEPT { return method_accessor<F, Policy>::get_is_reference();      }
         std::vector<bool> get_is_const()                    const RTTR_NOEXCEPT { return method_accessor<F, Policy>::get_is_const();          }
@@ -243,7 +243,7 @@ class constructor_wrapper<Class_Type, class_ctor, Acc_Level, Policy, Metadata_Co
         }
 
         bool is_valid()                  const RTTR_NOEXCEPT { return true; }
-        type get_instanciated_type()     const RTTR_NOEXCEPT { return type::get<instanciated_type>(); }
+        type get_instantiated_type()     const RTTR_NOEXCEPT { return type::get<instanciated_type>(); }
         type get_declaring_type()        const RTTR_NOEXCEPT { return type::get<typename raw_type<Class_Type>::type>(); }
         access_levels get_access_level() const RTTR_NOEXCEPT { return Acc_Level; }
 
@@ -329,7 +329,7 @@ class constructor_wrapper<ClassType, return_func, Acc_Level, Policy,
 
         bool is_valid()                                     const RTTR_NOEXCEPT { return true; }
         access_levels get_access_level()                    const RTTR_NOEXCEPT { return Acc_Level;                                           }
-        type get_instanciated_type()                        const RTTR_NOEXCEPT { return type::get<instanciated_type>();                      }
+        type get_instantiated_type()                        const RTTR_NOEXCEPT { return type::get<instanciated_type>();                      }
         type get_declaring_type()                           const RTTR_NOEXCEPT { return type::get<typename raw_type<ClassType>::type>();     }
         std::vector<bool> get_is_reference()                const RTTR_NOEXCEPT { return method_accessor<F, Policy>::get_is_reference();      }
         std::vector<bool> get_is_const()                    const RTTR_NOEXCEPT { return method_accessor<F, Policy>::get_is_const();          }

--- a/src/unit_tests/constructor/constructor_misc_test.cpp
+++ b/src/unit_tests/constructor/constructor_misc_test.cpp
@@ -112,18 +112,18 @@ TEST_CASE("constructor - default ctor binding type", "[constructor]")
 
 ////////////////////////////////////////////////////////////////////////////////////////
 
-TEST_CASE("constructor - get_instanciated_type", "[constructor]")
+TEST_CASE("constructor - get_instantiated_type", "[constructor]")
 {
     auto range = type::get<ctor_misc_test>().get_constructors();
     std::vector<constructor> ctor_list(range.cbegin(), range.cend());
     REQUIRE(ctor_list.size() >= 4);
 
-    CHECK(ctor_list[0].get_instanciated_type() == type::get<ctor_misc_test*>());
-    CHECK(ctor_list[1].get_instanciated_type() == type::get<std::shared_ptr<ctor_misc_test>>());
-    CHECK(ctor_list[2].get_instanciated_type() == type::get<ctor_misc_test>());
-    CHECK(ctor_list[3].get_instanciated_type() == type::get<ctor_misc_test>());
+    CHECK(ctor_list[0].get_instantiated_type() == type::get<ctor_misc_test*>());
+    CHECK(ctor_list[1].get_instantiated_type() == type::get<std::shared_ptr<ctor_misc_test>>());
+    CHECK(ctor_list[2].get_instantiated_type() == type::get<ctor_misc_test>());
+    CHECK(ctor_list[3].get_instantiated_type() == type::get<ctor_misc_test>());
     //negative test
-    CHECK(type::get_by_name("").get_constructor().get_instanciated_type().is_valid() == false);
+    CHECK(type::get_by_name("").get_constructor().get_instantiated_type().is_valid() == false);
 }
 
 ////////////////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
get_instanciated_type()" => "get_instantiated_type()"

REMARK: Minor API change because of type in "constructor" class!

fixes #83