### PR TITLE
added new function in type::register_wrapper_converter_for_base_classes<T>()

### DIFF
--- a/src/rttr/detail/impl/rttr_cast_impl.h
+++ b/src/rttr/detail/impl/rttr_cast_impl.h
@@ -39,8 +39,8 @@ namespace rttr
 template<typename Target_Type, typename Source_Type>
 RTTR_INLINE Target_Type rttr_cast(Source_Type object) RTTR_NOEXCEPT
 {
-    static_assert(detail::pointer_count<Target_Type>::value == 1, "Return type must be a pointer");
-    static_assert(detail::pointer_count<Target_Type>::value == 1, "Argument type must be a pointer");
+    static_assert(detail::pointer_count<Target_Type>::value == 1, "Target type must be a pointer");
+    static_assert(detail::pointer_count<Source_Type>::value == 1, "Source argument must be a pointer");
     static_assert(rttr::detail::has_get_type_func<Source_Type>::value, "Class has not type defined - please use the macro RTTR_ENABLE().");
 
     using Return_Type = detail::remove_pointer_t<Target_Type>;

--- a/src/rttr/detail/impl/wrapper_mapper_impl.h
+++ b/src/rttr/detail/impl/wrapper_mapper_impl.h
@@ -57,6 +57,21 @@ struct wrapper_mapper<std::shared_ptr<T>>
     {
         return type(t);
     }
+
+    template<typename U>
+    static std::shared_ptr<U> convert(const type& source, bool& ok)
+    {
+        if (auto p = rttr_cast<typename std::shared_ptr<U>::element_type*>(source.get()))
+        {
+            ok = true;
+            return std::shared_ptr<U>(source, p);
+        }
+        else
+        {
+            ok = false;
+            return std::shared_ptr<U>();
+        }
+    }
 };
 
 //////////////////////////////////////////////////////////////////////////////////////
@@ -75,6 +90,22 @@ struct wrapper_mapper<std::reference_wrapper<T>>
     static RTTR_INLINE type create(const wrapped_type& t)
     {
         return type(t);
+    }
+
+    template<typename U>
+    static std::reference_wrapper<U> convert(const type& source, bool& ok)
+    {
+        if (auto obj = rttr_cast<typename std::reference_wrapper<U>::type*>(&source.get()))
+        {
+            ok = true;
+            return std::ref(*obj);
+        }
+        else
+        {
+            ok = false;
+            U* dummy = nullptr;
+            return std::ref(*dummy); // this is illegal, however the value will be discarded anyway
+        }
     }
 };
 

--- a/src/rttr/detail/misc/register_wrapper_mapper_conversion.h
+++ b/src/rttr/detail/misc/register_wrapper_mapper_conversion.h
@@ -1,0 +1,126 @@
+/************************************************************************************
+*                                                                                   *
+*   Copyright (c) 2014, 2015 - 2017 Axel Menzel <info@rttr.org>                     *
+*                                                                                   *
+*   This file is part of RTTR (Run Time Type Reflection)                            *
+*   License: MIT License                                                            *
+*                                                                                   *
+*   Permission is hereby granted, free of charge, to any person obtaining           *
+*   a copy of this software and associated documentation files (the "Software"),    *
+*   to deal in the Software without restriction, including without limitation       *
+*   the rights to use, copy, modify, merge, publish, distribute, sublicense,        *
+*   and/or sell copies of the Software, and to permit persons to whom the           *
+*   Software is furnished to do so, subject to the following conditions:            *
+*                                                                                   *
+*   The above copyright notice and this permission notice shall be included in      *
+*   all copies or substantial portions of the Software.                             *
+*                                                                                   *
+*   THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR      *
+*   IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,        *
+*   FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE     *
+*   AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER          *
+*   LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,   *
+*   OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE   *
+*   SOFTWARE.                                                                       *
+*                                                                                   *
+*************************************************************************************/
+
+#ifndef RTTR_REGISTER_WRAPPER_MAPPER_CONVERSION_H_
+#define RTTR_REGISTER_WRAPPER_MAPPER_CONVERSION_H_
+
+#include "rttr/detail/base/core_prerequisites.h"
+
+#include "rttr/detail/misc/misc_type_traits.h"
+
+#include <type_traits>
+
+namespace rttr
+{
+namespace detail
+{
+
+/*!
+ * Determine if the given type \a T has a wrapper_mapper method called `convert`.
+ */
+template <typename T>
+class has_conversion_function_impl
+{
+    typedef char YesType[1];
+    typedef char NoType[2];
+
+    template <typename U> static YesType& check(decltype(&wrapper_mapper<U>::convert));
+    template <typename U> static NoType&  check(...);
+public:
+    static RTTR_CONSTEXPR_OR_CONST bool value = (sizeof(check<raw_type_t<T>>(0)) != sizeof(YesType));
+};
+
+/*!
+ * If \a T has a wrapper_mapper function `convert` then is the same like `std::true_type`, otherwise inherits from `std::false_type`.
+ */
+template<typename T>
+using has_wrapper_conv_func = std::integral_constant<bool, has_conversion_function_impl<T>::value>;
+
+/////////////////////////////////////////////////////////////////////////////////////
+
+/*!
+ * Registers for the given type \p DerivedClass a conversion function
+ * from \ref wrapper_mapper<T> from and to the types in the list `T...`.
+ */
+template<typename DerivedClass, typename... T>
+struct create_wrapper_conversion;
+
+template<typename DerivedClass>
+struct create_wrapper_conversion<DerivedClass>
+{
+    static RTTR_INLINE void perform() { }
+};
+
+template<typename DerivedClass, typename BaseClass, typename... U>
+struct create_wrapper_conversion<DerivedClass, BaseClass, U...>
+{
+    static RTTR_INLINE void perform()
+    {
+        static_assert(has_base_class_list<BaseClass>::value, "The parent class has no base class list defined - please use the macro RTTR_ENABLE");
+        type::register_converter_func(wrapper_mapper<DerivedClass>::template convert<BaseClass>);
+
+        using return_type = typename function_traits<decltype(&wrapper_mapper<DerivedClass>::template convert<BaseClass>)>::return_type;
+        // TO DO: remove raw_type_t, std::shared_ptr<const T> should also be converted, when necessary
+        using wrapped_derived_t = raw_type_t<wrapper_mapper_t<DerivedClass>>;
+        type::register_converter_func(wrapper_mapper<return_type>::template convert<wrapped_derived_t>);
+
+        create_wrapper_conversion<DerivedClass, typename BaseClass::base_class_list>::perform();
+        // continue with the rest
+        create_wrapper_conversion<DerivedClass, U...>::perform();
+    }
+};
+
+template<typename... U> struct type_list;
+
+template<typename DerivedClass, class... BaseClassList>
+struct create_wrapper_conversion<DerivedClass, type_list<BaseClassList...>> : create_wrapper_conversion<DerivedClass, BaseClassList...> { };
+
+/////////////////////////////////////////////////////////////////////////////////////
+
+template<typename T, typename Enable = void>
+struct reg_wrapper_converter_for_base_classes
+{
+    reg_wrapper_converter_for_base_classes()
+    {
+    }
+};
+
+template<typename T>
+struct reg_wrapper_converter_for_base_classes<T, typename std::enable_if<is_wrapper<T>::value && has_base_class_list<raw_type_t<wrapper_mapper_t<T>>>::value>::type>
+{
+    reg_wrapper_converter_for_base_classes()
+    {
+        create_wrapper_conversion<T, typename raw_type_t<wrapper_mapper_t<T>>::base_class_list>::perform();
+    }
+};
+
+/////////////////////////////////////////////////////////////////////////////////////
+
+}   // end namespace detail
+}   // end namespace rttr
+
+#endif // RTTR_REGISTER_WRAPPER_MAPPER_CONVERSION_H_

--- a/src/rttr/detail/misc/register_wrapper_mapper_conversion.h
+++ b/src/rttr/detail/misc/register_wrapper_mapper_conversion.h
@@ -82,8 +82,11 @@ struct create_wrapper_conversion<DerivedClass, BaseClass, U...>
     {
         static_assert(has_base_class_list<BaseClass>::value, "The parent class has no base class list defined - please use the macro RTTR_ENABLE");
         type::register_converter_func(wrapper_mapper<DerivedClass>::template convert<BaseClass>);
-
+#if RTTR_COMPILER == RTTR_COMPILER_MSVC && RTTR_COMP_VER <= 1800
+        using return_type = typename function_traits<decltype(identity_func(&wrapper_mapper<DerivedClass>::template convert<BaseClass>))>::return_type;
+#else
         using return_type = typename function_traits<decltype(&wrapper_mapper<DerivedClass>::template convert<BaseClass>)>::return_type;
+#endif
         // TO DO: remove raw_type_t, std::shared_ptr<const T> should also be converted, when necessary
         using wrapped_derived_t = raw_type_t<wrapper_mapper_t<DerivedClass>>;
         type::register_converter_func(wrapper_mapper<return_type>::template convert<wrapped_derived_t>);

--- a/src/rttr/detail/misc/utility.h
+++ b/src/rttr/detail/misc/utility.h
@@ -539,6 +539,14 @@ ends_with(const T& big_str, const T& small_str)
 
 /////////////////////////////////////////////////////////////////////////////////////////
 
+/*!
+ * A simple identity function. Returns the same object, without doing anything.
+ */
+template<typename T>
+static RTTR_INLINE T& identity_func(T& func) { return func; }
+
+/////////////////////////////////////////////////////////////////////////////////////////
+
 } // end namespace detail
 } // end namespace rttr
 

--- a/src/rttr/detail/type/type_impl.h
+++ b/src/rttr/detail/type/type_impl.h
@@ -41,6 +41,7 @@
 #include "rttr/detail/type/type_data.h"
 #include "rttr/detail/type/type_name.h"
 #include "rttr/detail/registration/registration_manager.h"
+#include "rttr/detail/misc/register_wrapper_mapper_conversion.h"
 
 
 namespace rttr
@@ -423,6 +424,14 @@ RTTR_INLINE void type::register_converter_func(F func)
     using source_type = remove_cv_t<remove_reference_t<source_type_orig>>;
 
     get_registration_manager().add_item(::rttr::detail::make_unique<type_converter<target_type, source_type, F>>(func));
+}
+
+/////////////////////////////////////////////////////////////////////////////////////////
+
+template<typename T>
+RTTR_INLINE void type::register_wrapper_converter_for_base_classes()
+{
+    detail::reg_wrapper_converter_for_base_classes<T>();
 }
 
 /////////////////////////////////////////////////////////////////////////////////////////

--- a/src/rttr/rttr.cmake
+++ b/src/rttr/rttr.cmake
@@ -113,6 +113,7 @@ set(HEADER_FILES access_levels.h
                  detail/misc/function_traits.h
                  detail/misc/iterator_wrapper.h
                  detail/misc/misc_type_traits.h
+                 detail/misc/register_wrapper_mapper_conversion.h
                  detail/misc/sequential_container_type_traits.h
                  detail/misc/std_type_traits.h
                  detail/misc/template_type_trait.h

--- a/src/rttr/type.h
+++ b/src/rttr/type.h
@@ -981,6 +981,33 @@ class RTTR_API type
         static void register_converter_func(F func);
 
         /*!
+         * \brief Register for all base classes of the giving type \p T
+         *        wrapper converter functions.
+         *        The converters are registered in both directions respectively.
+         *        From derived to base class and vice versa.
+         *
+         *
+         * See following example code:
+         *  \code{.cpp}
+         *   struct base { virtual ~base() {}; RTTR_ENABLE() };
+         *   struct derived : base { virtual ~derived() {}; RTTR_ENABLE(base) };
+         *
+         *   variant var = std::make_shared<derived>();
+         *   var.convert(type::get<std::shared_ptr<base>>());    // yields to `false`
+         *
+         *   // register the conversion functions
+         *   type::register_wrapper_converter_for_base_classes<std::shared_ptr<derived>>();
+         *
+         *   var.convert(type::get<std::shared_ptr<base>>());    // yields to `true`, derived to base conversion
+         *   var.convert(type::get<std::shared_ptr<derived>>()); // yields to `true`, base to derived conversion
+         *  \endcode
+         *
+         * \see variant::convert(), \ref wrapper_mapper "wrapper_mapper<T>"
+         */
+        template<typename T>
+        static void register_wrapper_converter_for_base_classes();
+
+        /*!
          * \brief Register comparison operators for template type \p T.
          *        This requires a valid `operator==` and `operator<` for type \p T.
          *

--- a/src/unit_tests/variant/variant_conv_test.cpp
+++ b/src/unit_tests/variant/variant_conv_test.cpp
@@ -76,18 +76,21 @@ static vector2d convert_to_vector(const point& p, bool& ok)
 
 struct base
 {
+    virtual ~base() {};
     int dummy;
     RTTR_ENABLE()
 };
 
 struct derived : virtual base
 {
+    virtual ~derived() {};
     double dummy2;
     RTTR_ENABLE(base)
 };
 
 struct other_derived : virtual base
 {
+    virtual ~other_derived() {};
     double dummy3;
     RTTR_ENABLE(base)
 };
@@ -785,6 +788,35 @@ TEST_CASE("variant test - convert from enum", "[variant]")
     CHECK(converted != test_enum::first);
     CHECK(converted == test_enum::second);
     CHECK(static_cast<int>(converted) == 2);
+}
+
+/////////////////////////////////////////////////////////////////////////////////////////
+
+TEST_CASE("variant test - register_wrapper_converter_for_base_classes<std::shared_ptr<T>>", "[variant]")
+{
+    variant var = std::make_shared<derived>();
+    CHECK(var.convert(type::get<std::shared_ptr<base>>())           == false);
+
+    type::register_wrapper_converter_for_base_classes<std::shared_ptr<derived>>();
+
+    CHECK(var.convert(type::get<std::shared_ptr<base>>())           == true);
+    CHECK(var.convert(type::get<std::shared_ptr<derived>>())        == true);
+    CHECK(var.convert(type::get<std::shared_ptr<other_derived>>())  == false);
+}
+
+/////////////////////////////////////////////////////////////////////////////////////////
+
+TEST_CASE("variant test - register_wrapper_converter_for_base_classes<std::reference_wrapper<T>>", "[variant]")
+{
+    derived obj;
+    variant var = std::ref(obj);
+    CHECK(var.convert(type::get<std::reference_wrapper<base>>())            == false);
+
+    type::register_wrapper_converter_for_base_classes<std::reference_wrapper<derived>>();
+
+    CHECK(var.convert(type::get<std::reference_wrapper<base>>())            == true);
+    CHECK(var.convert(type::get<std::reference_wrapper<derived>>())         == true);
+    CHECK(var.convert(type::get<std::reference_wrapper<other_derived>>())   == false);
 }
 
 /////////////////////////////////////////////////////////////////////////////////////////

--- a/src/unit_tests/variant/variant_conv_test.cpp
+++ b/src/unit_tests/variant/variant_conv_test.cpp
@@ -801,9 +801,9 @@ TEST_CASE("variant test - register_wrapper_converter_for_base_classes<std::share
 
     CHECK(var.convert(type::get<std::shared_ptr<base>>())           == true);
     CHECK(var.convert(type::get<std::shared_ptr<derived>>())        == true);
-    
+
     type::register_wrapper_converter_for_base_classes<std::shared_ptr<other_derived>>();
-    
+
     // negative test, we need first make a down cast, otherwise the target_type converter cannot be found
     CHECK(var.convert(type::get<std::shared_ptr<base>>())           == true);
     CHECK(var.convert(type::get<std::shared_ptr<other_derived>>())  == false);
@@ -821,7 +821,7 @@ TEST_CASE("variant test - register_wrapper_converter_for_base_classes<std::refer
 
     CHECK(var.convert(type::get<std::reference_wrapper<base>>())            == true);
     CHECK(var.convert(type::get<std::reference_wrapper<derived>>())         == true);
-    
+
     type::register_wrapper_converter_for_base_classes<std::reference_wrapper<other_derived>>();
     // negative test, we need first make a down cast, otherwise the target_type converter cannot be found
     CHECK(var.convert(type::get<std::reference_wrapper<base>>())            == true);

--- a/src/unit_tests/variant/variant_conv_test.cpp
+++ b/src/unit_tests/variant/variant_conv_test.cpp
@@ -801,6 +801,11 @@ TEST_CASE("variant test - register_wrapper_converter_for_base_classes<std::share
 
     CHECK(var.convert(type::get<std::shared_ptr<base>>())           == true);
     CHECK(var.convert(type::get<std::shared_ptr<derived>>())        == true);
+    
+    type::register_wrapper_converter_for_base_classes<std::shared_ptr<other_derived>>();
+    
+    // negative test, we need first make a down cast, otherwise the target_type converter cannot be found
+    CHECK(var.convert(type::get<std::shared_ptr<base>>())           == true);
     CHECK(var.convert(type::get<std::shared_ptr<other_derived>>())  == false);
 }
 
@@ -816,6 +821,10 @@ TEST_CASE("variant test - register_wrapper_converter_for_base_classes<std::refer
 
     CHECK(var.convert(type::get<std::reference_wrapper<base>>())            == true);
     CHECK(var.convert(type::get<std::reference_wrapper<derived>>())         == true);
+    
+    type::register_wrapper_converter_for_base_classes<std::reference_wrapper<other_derived>>();
+    // negative test, we need first make a down cast, otherwise the target_type converter cannot be found
+    CHECK(var.convert(type::get<std::reference_wrapper<base>>())            == true);
     CHECK(var.convert(type::get<std::reference_wrapper<other_derived>>())   == false);
 }
 


### PR DESCRIPTION
Register for all base classes of the giving type \p T
wrapper converter functions.
The converters are registered in both directions respectively.
From derived to base class and vice versa.

The wrapper_mapper class template, get therefore a new optional
functiont template:

template<typename U>
static std::shared_ptr<U> convert(const type& source, bool& ok)

For the wrapper classes: `std::shared_ptr<T>` and `std::reference_wrapper<T>`
default conversion functions are included.

Example:
```
struct base { virtual ~base() {}; RTTR_ENABLE() };
struct derived : base { virtual ~derived() {}; RTTR_ENABLE(base) };

variant var = std::make_shared<derived>();
var.convert(type::get<std::shared_ptr<base>>());    // yields to `false`

// register the conversion functions
type::register_wrapper_converter_for_base_classes<std::shared_ptr<derived>>();

var.convert(type::get<std::shared_ptr<base>>());    // yields to `true`, derived to base conversion
var.convert(type::get<std::shared_ptr<derived>>()); // yields to `true`, base to derived conversion
```