### PR TITLE
add c++11 flags in cmake build system

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -37,6 +37,10 @@ project ("rttr" LANGUAGES CXX)
 
 set(CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/CMake")
 
+#enforce requiring c++11 compatible compiler
+set(CMAKE_CXX_STANDARD 11)
+
+
 if (CMAKE_BUILD_TYPE STREQUAL "")
   # CMake defaults to leaving CMAKE_BUILD_TYPE empty. This screws up
   # differentiation between debug and release builds.


### PR DESCRIPTION
This patch enforces needing a c++11 compiler from within the CMake build system. Also adds appropriate c++11 flags in a cross platform way (e.g. if building on gcc < 5.0)