### PR TITLE
BUG - get_method/property uses "base" rather than "most derived"

### DIFF
--- a/src/unit_tests/method/method_order_test.cpp
+++ b/src/unit_tests/method/method_order_test.cpp
@@ -1,0 +1,172 @@
+/************************************************************************************
+*                                                                                   *
+*   Copyright (c) 2014 - 2018 Axel Menzel <info@rttr.org>                           *
+*                                                                                   *
+*   This file is part of RTTR (Run Time Type Reflection)                            *
+*   License: MIT License                                                            *
+*                                                                                   *
+*   Permission is hereby granted, free of charge, to any person obtaining           *
+*   a copy of this software and associated documentation files (the "Software"),    *
+*   to deal in the Software without restriction, including without limitation       *
+*   the rights to use, copy, modify, merge, publish, distribute, sublicense,        *
+*   and/or sell copies of the Software, and to permit persons to whom the           *
+*   Software is furnished to do so, subject to the following conditions:            *
+*                                                                                   *
+*   The above copyright notice and this permission notice shall be included in      *
+*   all copies or substantial portions of the Software.                             *
+*                                                                                   *
+*   THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR      *
+*   IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,        *
+*   FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE     *
+*   AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER          *
+*   LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,   *
+*   OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE   *
+*   SOFTWARE.                                                                       *
+*                                                                                   *
+*************************************************************************************/
+
+#include <rttr/registration>
+#include <catch/catch.hpp>
+#include <string>
+
+using namespace rttr;
+
+struct method_order_test_base
+{
+    method_order_test_base() = default ;
+    virtual ~method_order_test_base() = default ;
+
+    std::string whoami() { return "I am a base method" ; }
+    virtual std::string vwhoami() { return "I am a virtual base method" ; }
+
+    RTTR_ENABLE()
+
+};
+
+struct method_order_test_derived : method_order_test_base
+{
+    method_order_test_derived() = default ;
+    ~method_order_test_derived() override = default ;
+
+    std::string whoami() { return "I am a non-virtual derived method with same name" ; }
+    std::string vwhoami() override { return "I am a virtual derived method with same name" ; }
+
+    RTTR_ENABLE(method_order_test_base)
+};
+
+/////////////////////////////////////////////////////////////////////////////////////////
+
+RTTR_REGISTRATION
+{
+    registration::class_<method_order_test_base>("method_order_test_base")
+        .method("whoami", &method_order_test_base::whoami)
+        .method("vwhoami", &method_order_test_base::vwhoami)
+        ;
+    registration::class_<method_order_test_derived>("method_order_test_derived")
+        .method("whoami", &method_order_test_derived::whoami)
+        .method("vwhoami", &method_order_test_derived::vwhoami)
+        ;
+}
+
+// approach 1 looks up the "method instance"
+// without considering argument type
+// then invokes the function
+std::string rttr_invoke_approach1(
+        const rttr::instance& vinst,
+        const rttr::string_view& meth_name) {
+
+    const auto& inst_t = vinst.get_type();
+
+    // find method
+    const auto& meth = inst_t.get_method(meth_name);
+    REQUIRE(meth.is_valid() == true);
+
+    // invoke via method
+    const auto& iam_var = meth.invoke(vinst);
+    REQUIRE(iam_var.is_valid() == true);
+    REQUIRE(iam_var.is_type<std::string>() == true) ;
+
+    return iam_var.get_value<std::string>();
+}
+
+// approach 2 invokes the method via rttr::type
+// different rttr code - range based for loop
+std::string rttr_invoke_approach2(
+        const rttr::instance& vinst,
+        const rttr::string_view& meth_name) {
+
+    const auto& inst_t = vinst.get_type();
+
+    // invoke via type
+    const auto& iam_var = inst_t.invoke(meth_name, vinst, {});
+    REQUIRE(iam_var.is_valid() == true);
+    REQUIRE(iam_var.is_type<std::string>() == true) ;
+
+    return iam_var.get_value<std::string>();
+}
+
+template<class TT>
+void check_nonvirt_meth_order1() {
+    TT inst;
+    REQUIRE(inst.whoami() == rttr_invoke_approach1(inst, "whoami"));
+}
+
+template<class TT>
+void check_virt_meth_order1() {
+    TT inst;
+    REQUIRE(inst.vwhoami() == rttr_invoke_approach1(inst, "vwhoami"));
+}
+
+template<class TT>
+void check_nonvirt_meth_order2() {
+    TT inst;
+    REQUIRE(inst.whoami() == rttr_invoke_approach2(inst, "whoami"));
+}
+
+template<class TT>
+void check_virt_meth_order2() {
+    TT inst;
+    REQUIRE(inst.vwhoami() == rttr_invoke_approach2(inst, "vwhoami"));
+}
+
+/////////////////////////////////////////////////////////////////////////////////////////
+
+TEST_CASE("method - approach1_order_nonvirt_methods_base()", "[method]")
+{
+    check_nonvirt_meth_order1<method_order_test_base>();
+}
+
+TEST_CASE("method - approach1_order_nonvirt_methods_derived()", "[method]")
+{
+    check_nonvirt_meth_order1<method_order_test_derived>();
+}
+
+TEST_CASE("method - approach1_order_virt_methods_base()", "[method]")
+{
+    check_virt_meth_order1<method_order_test_base>();
+}
+
+TEST_CASE("method - approach1_order_nvirt_methods_derived()", "[method]")
+{
+    check_virt_meth_order1<method_order_test_derived>();
+}
+
+TEST_CASE("method - approach2_order_nonvirt_methods_base()", "[method]")
+{
+    check_nonvirt_meth_order2<method_order_test_base>();
+}
+
+TEST_CASE("method - approach2_order_nonvirt_methods_derived()", "[method]")
+{
+    check_nonvirt_meth_order2<method_order_test_derived>();
+}
+
+TEST_CASE("method - approach2_order_virt_methods_base()", "[method]")
+{
+    check_virt_meth_order2<method_order_test_base>();
+}
+
+TEST_CASE("method - approach2_order_nvirt_methods_derived()", "[method]")
+{
+    check_virt_meth_order2<method_order_test_derived>();
+}

--- a/src/unit_tests/property/property_order_test.cpp
+++ b/src/unit_tests/property/property_order_test.cpp
@@ -1,0 +1,149 @@
+/************************************************************************************
+*                                                                                   *
+*   Copyright (c) 2014 - 2018 Axel Menzel <info@rttr.org>                           *
+*                                                                                   *
+*   This file is part of RTTR (Run Time Type Reflection)                            *
+*   License: MIT License                                                            *
+*                                                                                   *
+*   Permission is hereby granted, free of charge, to any person obtaining           *
+*   a copy of this software and associated documentation files (the "Software"),    *
+*   to deal in the Software without restriction, including without limitation       *
+*   the rights to use, copy, modify, merge, publish, distribute, sublicense,        *
+*   and/or sell copies of the Software, and to permit persons to whom the           *
+*   Software is furnished to do so, subject to the following conditions:            *
+*                                                                                   *
+*   The above copyright notice and this permission notice shall be included in      *
+*   all copies or substantial portions of the Software.                             *
+*                                                                                   *
+*   THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR      *
+*   IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,        *
+*   FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE     *
+*   AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER          *
+*   LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,   *
+*   OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE   *
+*   SOFTWARE.                                                                       *
+*                                                                                   *
+*************************************************************************************/
+
+#include <rttr/registration>
+#include <catch/catch.hpp>
+#include <string>
+
+using namespace rttr;
+
+struct property_order_test_base
+{
+    property_order_test_base()
+        : _whoami( "I am a base property" )
+    {}
+    virtual ~property_order_test_base() = default ;
+
+    std::string _whoami ;
+
+    RTTR_ENABLE()
+
+};
+
+// RTTR_ENABLE incompatible with clang
+#define RTTR_ENABLE_OVERRIDE(...) \
+public:\
+    RTTR_INLINE rttr::type get_type() const override { return rttr::detail::get_type_from_instance(this); }  \
+    RTTR_INLINE void* get_ptr() override { return reinterpret_cast<void*>(this); } \
+    RTTR_INLINE rttr::detail::derived_info get_derived_info() override { return {reinterpret_cast<void*>(this), rttr::detail::get_type_from_instance(this)}; } \
+    using base_class_list = TYPE_LIST(__VA_ARGS__);
+
+
+struct property_order_test_derived : property_order_test_base
+{
+    property_order_test_derived()
+        : _whoami( "I am a derived property with same name" )
+    {}
+    ~property_order_test_derived() override = default ;
+
+    std::string _whoami ;
+
+    RTTR_ENABLE_OVERRIDE(property_order_test_base)
+};
+
+/////////////////////////////////////////////////////////////////////////////////////////
+
+RTTR_REGISTRATION
+{
+    registration::class_<property_order_test_base>("property_order_test_base")
+        .property("whoami", &property_order_test_base::_whoami)
+        ;
+    registration::class_<property_order_test_derived>("property_order_test_derived")
+        .property("whoami", &property_order_test_derived::_whoami)
+        ;
+}
+
+// approach 1 looks up the "property instance"
+// and gets the value from the property
+std::string rttr_prop_approach1(
+        const rttr::instance& vinst,
+        const rttr::string_view& prop_name )
+{
+    const auto& inst_t = vinst.get_type();
+
+    // find property
+    const auto& prop = inst_t.get_property(prop_name);
+    REQUIRE(prop.is_valid() == true);
+
+    // get value from property
+    const auto& iam_var = prop.get_value(vinst);
+    REQUIRE(iam_var.is_valid() == true);
+    REQUIRE(iam_var.is_type<std::string>() == true) ;
+
+    return iam_var.get_value<std::string>();
+}
+
+// approach 2 gets the property value from rttr::type
+std::string rttr_prop_approach2(
+        const rttr::instance& vinst,
+        const rttr::string_view& prop_name )
+{
+    const auto& inst_t = vinst.get_type();
+
+    // get_value via type
+    const auto& iam_var = inst_t.get_property_value(prop_name, vinst);
+    REQUIRE(iam_var.is_valid() == true);
+    REQUIRE(iam_var.is_type<std::string>() == true) ;
+
+    return iam_var.get_value<std::string>();
+}
+
+template<class TT>
+void check_prop_order1()
+{
+    TT inst;
+    REQUIRE( inst._whoami == rttr_prop_approach1(inst, "whoami") ) ;
+}
+
+template<class TT>
+void check_prop_order2()
+{
+    TT inst;
+    REQUIRE( inst._whoami == rttr_prop_approach2(inst, "whoami") ) ;
+}
+
+/////////////////////////////////////////////////////////////////////////////////////////
+
+TEST_CASE("property - approach1_order_properties_base()", "[property]")
+{
+    check_prop_order1<property_order_test_base>();
+}
+
+TEST_CASE("property - approach1_order_properties_derived()", "[property]")
+{
+    check_prop_order1<property_order_test_derived>();
+}
+
+TEST_CASE("property - approach2_order_properties_base()", "[property]")
+{
+    check_prop_order2<property_order_test_base>();
+}
+
+TEST_CASE("property - approach2_order_properties_derived()", "[property]")
+{
+    check_prop_order2<property_order_test_derived>();
+}

--- a/src/unit_tests/property/property_order_test.cpp
+++ b/src/unit_tests/property/property_order_test.cpp
@@ -44,15 +44,6 @@ struct property_order_test_base
 
 };
 
-// RTTR_ENABLE incompatible with clang
-#define RTTR_ENABLE_OVERRIDE(...) \
-public:\
-    RTTR_INLINE rttr::type get_type() const override { return rttr::detail::get_type_from_instance(this); }  \
-    RTTR_INLINE void* get_ptr() override { return reinterpret_cast<void*>(this); } \
-    RTTR_INLINE rttr::detail::derived_info get_derived_info() override { return {reinterpret_cast<void*>(this), rttr::detail::get_type_from_instance(this)}; } \
-    using base_class_list = TYPE_LIST(__VA_ARGS__);
-
-
 struct property_order_test_derived : property_order_test_base
 {
     property_order_test_derived()
@@ -60,9 +51,10 @@ struct property_order_test_derived : property_order_test_base
     {}
     ~property_order_test_derived() override = default ;
 
+    // member with SAME name as base
     std::string _whoami ;
 
-    RTTR_ENABLE_OVERRIDE(property_order_test_base)
+    RTTR_ENABLE(property_order_test_base)
 };
 
 /////////////////////////////////////////////////////////////////////////////////////////

--- a/src/unit_tests/unit_tests.cmake
+++ b/src/unit_tests/unit_tests.cmake
@@ -46,6 +46,7 @@ set(SOURCE_FILES main.cpp
                  property/property_class_invoke_wrapper.cpp
                  property/property_member_function.cpp
                  property/property_member_object.cpp
+                 property/property_order_test.cpp
                  property/property_global_function.cpp
                  property/property_global_object.cpp
                  type/test_type.cpp
@@ -69,6 +70,7 @@ set(SOURCE_FILES main.cpp
                  method/method_default_arg_test.cpp
                  method/method_misc_test.cpp
                  method/method_invoke_test.cpp
+                 method/method_order_test.cpp
                  method/method_param_info_test.cpp
                  method/method_query_test.cpp
                  variant/variant_assign_test.cpp


### PR DESCRIPTION
If you register the same function name in a derived class and in a base class
and call the function via a derived instance

C++ calls the derived method
RTTR calls the base method

RTTR searches from the "base class" to the derived class for the matching name.

The linear search of prop/meth vecs must use reverse iterator

staring from the most derived class registered.