### PR TITLE
fixed not correctly retrieved metadata for types

### DIFF
--- a/src/rttr/detail/type/type_register.cpp
+++ b/src/rttr/detail/type/type_register.cpp
@@ -1036,11 +1036,13 @@ variant type_register_private::get_metadata(const type& t, const variant& key)
 variant type_register_private::get_metadata(const variant& key, const std::vector<metadata>& data)
 {
     auto itr = std::lower_bound(data.cbegin(), data.cend(), key, metadata::order_by_key());
-    if (itr != data.cend())
+    while (itr != data.cend())
     {
         auto& item = *itr;
         if (item.get_key() == key)
             return item.get_value();
+        
+        ++itr;
     }
 
     return variant();

--- a/src/rttr/detail/type/type_register.cpp
+++ b/src/rttr/detail/type/type_register.cpp
@@ -1041,7 +1041,7 @@ variant type_register_private::get_metadata(const variant& key, const std::vecto
         auto& item = *itr;
         if (item.get_key() == key)
             return item.get_value();
-        
+
         ++itr;
     }
 

--- a/src/unit_tests/type/test_type.cpp
+++ b/src/unit_tests/type/test_type.cpp
@@ -30,7 +30,7 @@
 #include "unit_tests/test_classes.h"
 
 #include <catch/catch.hpp>
-#include <rttr/type>
+#include <rttr/registration>
 
 #include <vector>
 #include <map>
@@ -53,6 +53,24 @@ enum E_Alignment
 
 template<typename...Args>
 struct my_class_template {};
+
+struct type_metadata_test
+{
+
+};
+
+static const char* key_data = "Test";
+
+RTTR_REGISTRATION
+{
+    registration::class_<type_metadata_test>("type_metadata_test")
+            (
+                metadata(key_data, "foo"),
+                metadata("other_key", "bar"),
+                metadata("bar", 42),
+                metadata("foobar", "hello")
+            );
+}
 
 TEST_CASE("Test rttr::type - BasicTests", "[type]")
 {
@@ -602,5 +620,21 @@ TEST_CASE("Test rttr::type - get_types()", "[type]")
 {
     CHECK(type::get_types().size() > 1);
 }
+
+/////////////////////////////////////////////////////////////////////////////////////////
+
+TEST_CASE("Test rttr::type - get_metadata()", "[type]")
+{
+    auto t = type::get<type_metadata_test>();
+
+    CHECK(t.get_metadata(key_data).is_valid() == true);
+    CHECK(t.get_metadata("other_key").is_valid() == true);
+    CHECK(t.get_metadata("bar").is_valid() == true);
+    CHECK(t.get_metadata("foobar").is_valid() == true);
+
+    // negative
+    CHECK(t.get_metadata("novalid key").is_valid() == false);
+}
+
 
 /////////////////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
The algorithm was not correct, we had to iterate from the first find key to the end
Like it is done for the metadata for properties, methodes, etc.

fixes #172