### PR TITLE
Fixed errors due to missing virtual destructors in some unit tests.

### DIFF
--- a/src/unit_tests/instance/instance_test.cpp
+++ b/src/unit_tests/instance/instance_test.cpp
@@ -32,6 +32,8 @@ using namespace rttr;
 
 struct instance_base
 {
+    virtual ~instance_base() {}
+
     RTTR_ENABLE()
 };
 

--- a/src/unit_tests/test_classes.h
+++ b/src/unit_tests/test_classes.h
@@ -31,7 +31,7 @@
 #include <rttr/type>
 
 #define CLASS(CLASS_NAME) struct CLASS_NAME \
-{ RTTR_ENABLE() virtual int getType() { return dummyIntValue; } int dummyIntValue = 0; };
+{ virtual ~CLASS_NAME() {} RTTR_ENABLE() virtual int getType() { return dummyIntValue; } int dummyIntValue = 0; };
 
 #define CLASS_INHERIT(CLASS1, CLASS2) struct CLASS1 : CLASS2 \
 { virtual int getType() { return static_cast<int>(dummyDoubleValue); } RTTR_ENABLE(CLASS2) double dummyDoubleValue = 1; };


### PR DESCRIPTION
Error with clang on OS X are of the form

```
error: destructor called on non-final 'ClassSingle6A' that has virtual functions but non-virtual destructor [-Werror,-Wdelete-non-virtual-dtor]
```

```
error: destructor called on non-final 'instance_derived' that has virtual functions but non-virtual destructor [-Werror,-Wdelete-non-virtual-dtor]
```