### PR TITLE
Clang override error

### DIFF
--- a/src/unit_tests/misc/test_misc.cpp
+++ b/src/unit_tests/misc/test_misc.cpp
@@ -40,6 +40,23 @@ using namespace std;
 
 ////////////////////////////////////////////////////////////////////////////////////////
 
+#include <rttr/registration>
+
+struct s_base
+{
+    virtual ~s_base() = default; // always use virtual dtor in base class
+    RTTR_ENABLE()
+};
+
+struct s_derived : s_base
+{
+    ~s_derived() override = default;
+    // Clang options require "override" on inherited virtual functions
+    RTTR_ENABLE(s_base)
+};
+
+////////////////////////////////////////////////////////////////////////////////////////
+
 namespace
 {
     struct custom_type


### PR DESCRIPTION
Clang options can enforce
- virtual methods in base CANNOT have "override", need "virtual"
- virtual methods in derived MUST have "override", rather than "virtual"
- warning is error

struct s_base
{
    virtual ~s_base() = default; // always use virtual dtor in base class
    RTTR_ENABLE()
};

struct s_derived : s_base
{
    ~s_derived() override = default;
    // Clang options require "override" on inherited virtual functions
    RTTR_ENABLE(s_base)
};

https://travis-ci.org/rttrorg/rttr/jobs/426502240

/home/travis/build/rttrorg/rttr/src/unit_tests/misc/test_misc.cpp:55:5: error: 'get_derived_info' overrides a member function but is not marked 'override' [-Werror,-Winconsistent-missing-override]
/home/travis/build/rttrorg/rttr/src/unit_tests/misc/test_misc.cpp:55:5: error: 'get_ptr' overrides a member function but is not marked 'override' [-Werror,-Winconsistent-missing-override]
/home/travis/build/rttrorg/rttr/src/unit_tests/misc/test_misc.cpp:55:5: error: 'get_type' overrides a member function but is not marked 'override' [-Werror,-Winconsistent-missing-override]