### PR TITLE
Bugfix clang virtual override warning

### DIFF
--- a/src/rttr/detail/base/core_prerequisites.h
+++ b/src/rttr/detail/base/core_prerequisites.h
@@ -304,7 +304,7 @@ namespace rttr
 #       define RTTR_END_DISABLE_EXCEPT_TYPE_WARNING
 #endif
 
-#if defined(__has_warning) && __has_warning("-Winconsistent-missing-override)
+#if defined(__has_warning) && __has_warning("-Winconsistent-missing-override")
 #   define RTTR_BEGIN_DISABLE_OVERRIDE_WARNING          _Pragma ("clang diagnostic push") \
                                                         _Pragma ("clang diagnostic ignored \"-Winconsistent-missing-override\"")
 #   define RTTR_END_DISABLE_OVERRIDE_WARNING            _Pragma ("clang diagnostic pop")

--- a/src/rttr/detail/base/core_prerequisites.h
+++ b/src/rttr/detail/base/core_prerequisites.h
@@ -261,15 +261,21 @@ namespace rttr
 #   define RTTR_BEGIN_DISABLE_CONDITIONAL_EXPR_WARNING
 #   define RTTR_END_DISABLE_CONDITIONAL_EXPR_WARNING
 #if RTTR_COMP_VER >= 700
-
     #define RTTR_BEGIN_DISABLE_EXCEPT_TYPE_WARNING      _Pragma ("GCC diagnostic push") \
                                                         _Pragma ("GCC diagnostic ignored \"-Wnoexcept-type\"")
     #define RTTR_END_DISABLE_EXCEPT_TYPE_WARNING        _Pragma ("GCC diagnostic pop")
 #else
-
     #define RTTR_BEGIN_DISABLE_EXCEPT_TYPE_WARNING
     #define RTTR_END_DISABLE_EXCEPT_TYPE_WARNING
+#endif
 
+#if RTTR_COMP_VER >= 510
+#   define RTTR_BEGIN_DISABLE_OVERRIDE_WARNING        _Pragma ("GCC diagnostic push") \
+                                                      _Pragma ("GCC diagnostic ignored \"-Wsuggest-override\"")
+#   define RTTR_END_DISABLE_OVERRIDE_WARNING          _Pragma ("GCC diagnostic pop")
+# else
+#   define RTTR_BEGIN_DISABLE_OVERRIDE_WARNING
+#   define RTTR_END_DISABLE_OVERRIDE_WARNING
 #endif
 
 #   define RTTR_DECLARE_PLUGIN_CTOR       __attribute__((constructor))
@@ -298,6 +304,15 @@ namespace rttr
 #       define RTTR_END_DISABLE_EXCEPT_TYPE_WARNING
 #endif
 
+#if defined(__has_warning) && __has_warning("-Winconsistent-missing-override)
+#   define RTTR_BEGIN_DISABLE_OVERRIDE_WARNING          _Pragma ("clang diagnostic push") \
+                                                        _Pragma ("clang diagnostic ignored \"-Winconsistent-missing-override\"")
+#   define RTTR_END_DISABLE_OVERRIDE_WARNING            _Pragma ("clang diagnostic pop")
+#else
+#   define RTTR_BEGIN_DISABLE_OVERRIDE_WARNING
+#   define RTTR_END_DISABLE_OVERRIDE_WARNING
+#endif
+
 #   define RTTR_DECLARE_PLUGIN_CTOR        __attribute__((__constructor__))
 #   define RTTR_DECLARE_PLUGIN_DTOR        __attribute__((__destructor__))
 
@@ -315,6 +330,8 @@ namespace rttr
 #   define RTTR_END_DISABLE_EXCEPT_TYPE_WARNING
 #   define RTTR_DECLARE_PLUGIN_CTOR
 #   define RTTR_DECLARE_PLUGIN_DTOR
+#   define RTTR_BEGIN_DISABLE_OVERRIDE_WARNING
+#   define RTTR_END_DISABLE_OVERRIDE_WARNING
 
 #else
 #   pragma message("WARNING: unknown compiler, don't know how to disable deprecated warnings")

--- a/src/rttr/rttr_enable.h
+++ b/src/rttr/rttr_enable.h
@@ -81,10 +81,12 @@
 
 #define RTTR_ENABLE(...) \
 public:\
+RTTR_BEGIN_DISABLE_OVERRIDE_WARNING \
     virtual RTTR_INLINE ::rttr::type get_type() const { return ::rttr::detail::get_type_from_instance(this); }  \
     virtual RTTR_INLINE void* get_ptr() { return reinterpret_cast<void*>(this); } \
     virtual RTTR_INLINE ::rttr::detail::derived_info get_derived_info() { return {reinterpret_cast<void*>(this), ::rttr::detail::get_type_from_instance(this)}; } \
     using base_class_list = TYPE_LIST(__VA_ARGS__); \
+RTTR_END_DISABLE_OVERRIDE_WARNING \
 private:
 
 #endif // DOXYGEN

--- a/src/unit_tests/property/property_class_inheritance.cpp
+++ b/src/unit_tests/property/property_class_inheritance.cpp
@@ -56,6 +56,7 @@ struct left : virtual top
 {
 
     left() : _p2(true){}
+    ~left() override = default;
     bool _p2;
 
     RTTR_ENABLE(top)
@@ -67,6 +68,7 @@ struct right : virtual top
 {
 
     right() : _p3(true){}
+    ~right() override = default;
     bool _p3;
 
     RTTR_ENABLE(top)
@@ -77,6 +79,7 @@ struct right : virtual top
 struct right_2
 {
     virtual ~right_2() {}
+
     right_2() : _p4(true){}
     bool _p4;
     RTTR_ENABLE()
@@ -87,6 +90,7 @@ struct right_2
 struct bottom : left, right, right_2
 {
     bottom() : _p5(23.0){}
+     ~bottom() override = default;
 
     double _p5;
 


### PR DESCRIPTION
fixed missing use of 'override' in classes that use RTTR_ENABLE

following test case:

struct s_base
{
virtual ~s_base() = default; // always use virtual dtor in base class
RTTR_ENABLE()
};

struct s_derived : s_base
{
~s_derived() override = default;
// Clang options require "override" on inherited virtual functions
RTTR_ENABLE(s_base)
};

clang warning is: 'get_derived_info' overrides a member function but is not marked 'override' [-Werror,-Winconsistent-missing-override]

The fix is to disable the warning for the usage of RTTR_ENABLE only

