### PR TITLE
Support all LP64 architectures

### DIFF
--- a/src/rttr/detail/base/core_prerequisites.h
+++ b/src/rttr/detail/base/core_prerequisites.h
@@ -89,7 +89,7 @@ namespace rttr
 // Architecture
 /////////////////////////////////////////////////////////////////////////////////////////
 #if defined(__x86_64__) || defined(_M_X64) || defined(__powerpc64__) || defined(__alpha__) ||\
-    defined(__ia64__) || defined(__s390__) || defined(__s390x__)
+    defined(__ia64__) || defined(__s390__) || defined(__s390x__) || defined(_LP64) || defined(__LP64__)
 #   define RTTR_ARCH_TYPE RTTR_ARCH_64
 #else
 #   define RTTR_ARCH_TYPE RTTR_ARCH_32


### PR DESCRIPTION
This fixes the build on aarch64 and riscv64.

https://build.opensuse.org/package/show/home:Andreas_Schwab:Factory/rttr