### PR TITLE
Tests fix

### DIFF
--- a/src/unit_tests/CMakeLists.txt
+++ b/src/unit_tests/CMakeLists.txt
@@ -53,7 +53,7 @@ set_target_properties(unit_tests PROPERTIES DEBUG_POSTFIX ${RTTR_DEBUG_POSTFIX}
                                             CXX_STANDARD ${MAX_CXX_STANDARD})
 
 set_compiler_warnings(unit_tests)
-if (CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+if (CMAKE_CXX_COMPILER_ID MATCHES "Clang" AND CMAKE_CXX_COMPILER_VERSION VERSION_GREATER 6.0.1)
     target_compile_options(unit_tests PRIVATE -Wno-error=self-assign-overloaded)
 endif()
 

--- a/src/unit_tests/CMakeLists.txt
+++ b/src/unit_tests/CMakeLists.txt
@@ -53,7 +53,9 @@ set_target_properties(unit_tests PROPERTIES DEBUG_POSTFIX ${RTTR_DEBUG_POSTFIX}
                                             CXX_STANDARD ${MAX_CXX_STANDARD})
 
 set_compiler_warnings(unit_tests)
-target_compile_options(unit_tests PRIVATE -Wno-error=self-assign-overloaded)
+if (CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+    target_compile_options(unit_tests PRIVATE -Wno-error=self-assign-overloaded)
+endif()
 
 if (MSVC)
     target_compile_options(unit_tests PRIVATE /bigobj) 

--- a/src/unit_tests/CMakeLists.txt
+++ b/src/unit_tests/CMakeLists.txt
@@ -53,6 +53,7 @@ set_target_properties(unit_tests PROPERTIES DEBUG_POSTFIX ${RTTR_DEBUG_POSTFIX}
                                             CXX_STANDARD ${MAX_CXX_STANDARD})
 
 set_compiler_warnings(unit_tests)
+target_compile_options(unit_tests PRIVATE -Wno-error=self-assign-overloaded)
 
 if (MSVC)
     target_compile_options(unit_tests PRIVATE /bigobj) 


### PR DESCRIPTION
In newer versions of Clang (above 6.0.1), unit_tests fail to compile due to warning self-assign-overloaded being treated as an error. Examples at variant_assign_test.cpp:156 and variant_assign_test.cpp:164.

With this PR, the warnings are still shown, but, they are not treated as errors.