### PR TITLE
#252 Compiler error because src\rttr\variant.h doesn't include <string>.

### DIFF
--- a/src/rttr/variant.h
+++ b/src/rttr/variant.h
@@ -38,6 +38,7 @@
 #include <cstddef>
 #include <cstdint>
 #include <algorithm>
+#include <string>
 
 namespace rttr
 {


### PR DESCRIPTION
Fix compiler errors.