### PR TITLE
Make thread support optional for WASM

### DIFF
--- a/3rd_party/chaiscript-6.1.0/chaiscript/dispatchkit/type_conversions.hpp
+++ b/3rd_party/chaiscript-6.1.0/chaiscript/dispatchkit/type_conversions.hpp
@@ -11,7 +11,9 @@
 #ifndef CHAISCRIPT_DYNAMIC_CAST_CONVERSION_HPP_
 #define CHAISCRIPT_DYNAMIC_CAST_CONVERSION_HPP_
 
+#ifndef RTTR_NO_CXX11_THREAD
 #include <atomic>
+#endif
 #include <memory>
 #include <set>
 #include <stdexcept>

--- a/3rd_party/chaiscript-develop/chaiscript/dispatchkit/type_conversions.hpp
+++ b/3rd_party/chaiscript-develop/chaiscript/dispatchkit/type_conversions.hpp
@@ -11,7 +11,9 @@
 #ifndef CHAISCRIPT_DYNAMIC_CAST_CONVERSION_HPP_
 #define CHAISCRIPT_DYNAMIC_CAST_CONVERSION_HPP_
 
+#ifndef RTTR_NO_CXX11_THREAD
 #include <atomic>
+#endif
 #include <memory>
 #include <set>
 #include <stdexcept>

--- a/src/rttr/detail/type/type_register.cpp
+++ b/src/rttr/detail/type/type_register.cpp
@@ -491,7 +491,9 @@ type_data* type_register_private::register_name_if_neccessary(type_data* info)
     if (ret != m_orig_name_to_id.end())
         return ret->m_type_data;
 
+#ifndef RTTR_NO_CXX11_THREAD
     std::lock_guard<std::mutex> lock(m_mutex);
+#endif
 
     m_orig_name_to_id.insert(std::make_pair(info->type_name, type(info)));
     info->name = derive_name(type(info));
@@ -556,7 +558,9 @@ type_data* type_register_private::register_type(type_data* info) RTTR_NOEXCEPT
     info->raw_type_data  = !info->raw_type_data->is_valid ? info : info->raw_type_data;
 
     {
+#ifndef RTTR_NO_CXX11_THREAD
         std::lock_guard<std::mutex> lock(m_mutex);
+#endif
         m_type_data_storage.push_back(info);
     }
 
@@ -607,7 +611,9 @@ void type_register_private::unregister_type(type_data* info) RTTR_NOEXCEPT
     // REMARK: the base_types has to be provided as argument explicitely and cannot be retrieve via the type_data itself,
     // because the `class_data` which holds the base_types information cannot be retrieve via the function `get_class_data`
     // anymore because the containing std::unique_ptr is already destroyed
+#ifndef RTTR_NO_CXX11_THREAD
     std::lock_guard<std::mutex> lock(m_mutex);
+#endif
 
     bool found_type_data = false;
 
@@ -672,7 +678,9 @@ std::string type_register_private::derive_template_instance_name(type_data* info
 
 void type_register_private::update_custom_name(std::string new_name, const type& t)
 {
+#ifndef RTTR_NO_CXX11_THREAD
     std::lock_guard<std::mutex> lock(m_mutex);
+#endif
 
     auto& type_name = t.m_type_data->name;
 

--- a/src/rttr/detail/type/type_register_p.h
+++ b/src/rttr/detail/type/type_register_p.h
@@ -40,7 +40,10 @@
 #include <memory>
 #include <string>
 #include <vector>
+
+#ifndef RTTR_NO_CXX11_THREAD
 #include <mutex>
+#endif
 
 namespace rttr
 {
@@ -227,7 +230,9 @@ private:
     std::vector<data_container<const type_comparator_base*>>    m_type_equal_cmp_list;
     std::vector<data_container<const type_comparator_base*>>    m_type_less_than_cmp_list;
 
+#ifndef RTTR_NO_CXX11_THREAD
     std::mutex                                                  m_mutex;
+#endif
 };
 
 } // end namespace detail

--- a/src/rttr/library.cpp
+++ b/src/rttr/library.cpp
@@ -29,7 +29,10 @@
 #include "rttr/detail/library/library_p.h"
 
 #include <map>
+
+#ifndef RTTR_NO_CXX11_THREAD
 #include <mutex>
+#endif
 
 namespace rttr
 {
@@ -49,7 +52,9 @@ class library_manager
         static std::shared_ptr<library_private> create_or_find_library(string_view file_name, string_view version)
         {
             auto& manager = get_instance();
+#ifndef RTTR_NO_CXX11_THREAD
             std::lock_guard<std::mutex> lock(manager.m_library_mutex);
+#endif
 
             auto file_as_string = file_name.to_string();
             auto itr = manager.m_library_map.find(file_as_string);
@@ -71,7 +76,9 @@ class library_manager
         static void remove_item(const std::shared_ptr<library_private>& item)
         {
             auto& manager = get_instance();
+#ifndef RTTR_NO_CXX11_THREAD
             std::lock_guard<std::mutex> lock(manager.m_library_mutex);
+#endif
 
             auto itr = manager.m_library_map.find(item->get_file_name().to_string()); // because we use string_view to find the item
             if (itr != manager.m_library_map.end())
@@ -102,7 +109,10 @@ class library_manager
 
         // use std::less in order to use string_view for finding the item
         std::map<std::string, std::shared_ptr<library_private>> m_library_map;
+
+#ifndef RTTR_NO_CXX11_THREAD
         std::mutex m_library_mutex;
+#endif
 };
 }
 

--- a/src/rttr/type.cpp
+++ b/src/rttr/type.cpp
@@ -49,11 +49,14 @@
 #include <vector>
 #include <memory>
 #include <set>
-#include <thread>
-#include <mutex>
 #include <cstring>
 #include <cctype>
 #include <utility>
+
+#ifndef RTTR_NO_CXX11_THREAD
+#include <thread>
+#include <mutex>
+#endif
 
 using namespace std;
 


### PR DESCRIPTION
Compiling to WebAssembly with the wasi-sdk which uses wasi-libc, and has no thread support implemented yet. If there's a better way to do this let me know, as I attempted to somewhat mirror the RTTR_NO_CXX** defines.