### PR TITLE
Provide stubs if dlfcn.h does not exist

### DIFF
--- a/src/rttr/detail/library/library_unix.cpp
+++ b/src/rttr/detail/library/library_unix.cpp
@@ -34,8 +34,32 @@
 #include "rttr/detail/misc/utility.h"
 
 #include <vector>
-#include <dlfcn.h>
 #include <cstdio>
+
+#if defined __has_include
+#if __has_include(<dlfcn.h>)
+#include <dlfcn.h>
+#else
+
+#define RTLD_NOW 0
+
+void* dlopen(const char* file, int mode) {
+    return nullptr;
+}
+
+char* dlerror(void) {
+    static char error[] = "Not supported";
+    return error;
+}
+
+int dlclose(void* handle) {
+    return 1;
+}
+
+#endif
+#else
+#include <dlfcn.h>
+#endif
 
 namespace
 {


### PR DESCRIPTION
For compiling under WebAssembly with the wasi-sdk / wasi-libc. Even though the platforms have many POSIX functions implemented, they do not have dlopen etc. This checks if the header exists, and if it does it includes it, otherwise it provides stubs that always return null / errors. If a compiler does not support __has_include, it will just include dlfcn.h as a fallback. Most (if not all) wasm platforms are using at least clang 9, which is when native wasm was added to clang, and they support __has_include.