### PR TITLE
linux: fix unit unit_tests plugin loading

### DIFF
--- a/src/unit_tests/CMakeLists.txt
+++ b/src/unit_tests/CMakeLists.txt
@@ -55,16 +55,16 @@ set_target_properties(unit_tests PROPERTIES DEBUG_POSTFIX ${RTTR_DEBUG_POSTFIX}
 set_compiler_warnings(unit_tests)
 
 if (MSVC)
-    target_compile_options(unit_tests PRIVATE /bigobj) 
+    target_compile_options(unit_tests PRIVATE /bigobj)
 endif()
-                                            
+
 # run tests
 add_custom_target(run_tests ALL
-                  COMMAND "$<TARGET_FILE:unit_tests>"
+                  COMMAND ${CMAKE_COMMAND} -E env LD_LIBRARY_PATH=${CMAKE_BINARY_DIR}/lib "$<TARGET_FILE:unit_tests>"
                   DEPENDS unit_tests
                   COMMENT "Running unit_tests")
-                  
-set_target_properties(run_tests PROPERTIES 
+
+set_target_properties(run_tests PROPERTIES
                                 FOLDER "Testing")
 
 add_subdirectory(plugin)


### PR DESCRIPTION
LD_LIBRARY_PATH was not set correctly