### PR TITLE
fix thread-safety issues

### DIFF
--- a/src/rttr/detail/type/type_register.cpp
+++ b/src/rttr/detail/type/type_register.cpp
@@ -1115,9 +1115,13 @@ flat_map<string_view, type>& type_register_private::get_orig_name_to_id()
 
 /////////////////////////////////////////////////////////////////////////////////////
 
-flat_map<std::string, type, hash>& type_register_private::get_custom_name_to_id()
+type type_register_private::get_type_by_custom_name(string_view name)
 {
-    return m_custom_name_to_id;
+    std::lock_guard<std::mutex> lock(m_mutex);
+    auto ret = m_custom_name_to_id.find(name);
+    if (ret != m_custom_name_to_id.end())
+        return (*ret);
+    return detail::get_invalid_type();
 }
 
 /////////////////////////////////////////////////////////////////////////////////////

--- a/src/rttr/detail/type/type_register_p.h
+++ b/src/rttr/detail/type/type_register_p.h
@@ -103,7 +103,7 @@ public:
     std::vector<type_data*>& get_type_data_storage();
     std::vector<type>& get_type_storage();
     flat_map<string_view, type>& get_orig_name_to_id();
-    flat_map<std::string, type, hash>& get_custom_name_to_id();
+    type get_type_by_custom_name(string_view name);
 
     /////////////////////////////////////////////////////////////////////////////////////
 

--- a/src/rttr/type.cpp
+++ b/src/rttr/type.cpp
@@ -477,12 +477,7 @@ variant type::invoke(string_view name, std::vector<argument> args)
 
 type type::get_by_name(string_view name) RTTR_NOEXCEPT
 {
-    auto& custom_name_to_id = detail::type_register_private::get_instance().get_custom_name_to_id();
-    auto ret = custom_name_to_id.find(name);
-    if (ret != custom_name_to_id.end())
-        return (*ret);
-
-    return detail::get_invalid_type();
+    return detail::type_register_private::get_instance().get_type_by_custom_name(name);
 }
 
 /////////////////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
`custom_name_to_id` was being used in thread-unsafe way by
`type::get_by_name`. Fixed that.