### PR TITLE
Support x64-android

### DIFF
--- a/src/rttr/detail/conversion/number_conversion.h
+++ b/src/rttr/detail/conversion/number_conversion.h
@@ -134,9 +134,9 @@ typename std::enable_if<std::is_floating_point<F>::value &&
                         bool>::type
 convert_to(const F& from, T& to)
 {
-    if (from > std::numeric_limits<T>::max())
+    if (from > static_cast<F>(std::numeric_limits<T>::max()))
         return false; // value too large
-    else if (from < -std::numeric_limits<T>::max())
+    else if (from < -static_cast<F>(std::numeric_limits<T>::max()))
         return false; // value to small
 
     to = static_cast<T>(from);
@@ -151,7 +151,7 @@ typename std::enable_if<std::is_floating_point<F>::value &&
                         bool>::type
 convert_to(const F& from, T& to)
 {
-    if (from < 0 || from > std::numeric_limits<T>::max())
+    if (from < 0 || from > static_cast<F>(std::numeric_limits<T>::max()))
         return false; // value too large
 
     to = static_cast<T>(from);


### PR DESCRIPTION
**Describe the bug**

Implicit type conversion rules in C++. In C++, if two values of different types are operated on or compared, the compiler attempts an implicit type conversion to convert one value to the type of the other. This implicit type conversion may result in loss of precision, overflow, or incorrect results。

That's why I used the explicit conversion result.


**Environment**

OS: Ubuntu 20.04.6 LTS
Compiler: gcc 9.4.0


Use: vcpkg

To reproduce:
Run command:
```
./vcpkg install rttr:x64-android
```