### PR TITLE
Fix error C2668: 'operator new[]': ambiguous call to overloaded function

### DIFF
--- a/src/rttr/detail/misc/misc_type_traits.h
+++ b/src/rttr/detail/misc/misc_type_traits.h
@@ -894,6 +894,18 @@ namespace detail
      {
      };
 
+    /////////////////////////////////////////////////////////////////////////////////////////
+
+    template <class T>
+    struct is_bounded_array : std::false_type
+    {
+    };
+
+    template <class T, std::size_t N>
+    struct is_bounded_array<T[N]> : std::true_type
+    {
+    };
+
 } // end namespace detail
 } // end namespace rttr
 

--- a/src/rttr/detail/misc/misc_type_traits.h
+++ b/src/rttr/detail/misc/misc_type_traits.h
@@ -894,18 +894,6 @@ namespace detail
      {
      };
 
-    /////////////////////////////////////////////////////////////////////////////////////////
-
-    template <class T>
-    struct is_bounded_array : std::false_type
-    {
-    };
-
-    template <class T, std::size_t N>
-    struct is_bounded_array<T[N]> : std::true_type
-    {
-    };
-
 } // end namespace detail
 } // end namespace rttr
 

--- a/src/rttr/detail/variant/variant_data_policy.h
+++ b/src/rttr/detail/variant/variant_data_policy.h
@@ -516,7 +516,7 @@ struct variant_data_policy_array_big : variant_data_base_policy<T, variant_data_
 
     static RTTR_INLINE void clone(const T& value, variant_data& dest)
     {
-        if constexpr (std::is_bounded_array_v<T>)
+        if constexpr (rttr::detail::is_bounded_array<T>::value)
         {
             constexpr size_t size = std::extent_v<T>;
             using Type = std::remove_extent_t<T>;
@@ -539,7 +539,7 @@ struct variant_data_policy_array_big : variant_data_base_policy<T, variant_data_
     static RTTR_INLINE void create(U&& value, variant_data& dest)
     {
         using array_dest_type = decltype(new T);
-        if constexpr (std::is_bounded_array_v<T>)
+        if constexpr (rttr::detail::is_bounded_array<T>::value)
         {
             constexpr size_t size = std::extent_v<T>;
             using Type = std::remove_extent_t<T>;

--- a/src/rttr/detail/variant/variant_data_policy.h
+++ b/src/rttr/detail/variant/variant_data_policy.h
@@ -516,7 +516,16 @@ struct variant_data_policy_array_big : variant_data_base_policy<T, variant_data_
 
     static RTTR_INLINE void clone(const T& value, variant_data& dest)
     {
-        reinterpret_cast<array_dest_type&>(dest) = new T;
+        if constexpr (std::is_bounded_array_v<T>)
+        {
+            constexpr size_t size = std::extent_v<T>;
+            using Type = std::remove_extent_t<T>;
+            reinterpret_cast<array_dest_type&>(dest) = new Type[size];
+        }
+        else
+        {
+            reinterpret_cast<array_dest_type&>(dest) = new T;
+        }
 
         COPY_ARRAY_PRE_PROC(value, dest);
     }
@@ -530,7 +539,16 @@ struct variant_data_policy_array_big : variant_data_base_policy<T, variant_data_
     static RTTR_INLINE void create(U&& value, variant_data& dest)
     {
         using array_dest_type = decltype(new T);
-        reinterpret_cast<array_dest_type&>(dest) = new T;
+        if constexpr (std::is_bounded_array_v<T>)
+        {
+            constexpr size_t size = std::extent_v<T>;
+            using Type = std::remove_extent_t<T>;
+            reinterpret_cast<array_dest_type&>(dest) = new Type[size];
+        }
+        else
+        {
+            reinterpret_cast<array_dest_type&>(dest) = new T;
+        }
 
         COPY_ARRAY_PRE_PROC(value, dest);
     }


### PR DESCRIPTION
See #346 
Note that `std::is_bounded_array` is introduced in C++20.